### PR TITLE
Custom fonts and color design system

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,10 @@
 # Omakase Ruby styling for Rails
 inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 
+AllCops:
+  Exclude:
+    - "app/assets/**/*"
+
 # Overwrite or add rules to create your own house style
 #
 # # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,31 @@ All primary keys are string UUIDs. Key models:
 
 Controllers under `app/controllers/accounts/api/v1/` inherit from `ActionController::API` (no views). Recipes expose `to_api_response` and `to_meal_planning_response` serialization methods directly on the model.
 
+### Design System
+
+Defined in `app/assets/tailwind/application.css` using Tailwind v4 `@theme` block.
+
+**Fonts** (Google Fonts, loaded in both layouts):
+- `font-display` — Bitter (slab-serif, headings)
+- `font-sans` (default body) — Nunito Sans
+
+**Color tokens** — use these instead of raw Tailwind colors:
+- `primary-*` (50–900) — Terracotta. Buttons, links, navbar, active states.
+- `accent-*` (50–900) — Saffron/golden. Secondary CTAs, highlights.
+- `warm-*` (50–900) — Warm neutrals. Text, borders, backgrounds. Replaces gray.
+- `red-*`, `green-*`, `yellow-*` — kept as standard Tailwind for alerts, success, warnings.
+
+**Custom CSS classes:**
+- `.bg-warm-gradient` — warm body background (cream→peach gradient)
+- `.card-warm` — frosted glass card with warm shadow
+- `.nav-warm` — navbar gradient (dark→light terracotta)
+
+**Conventions:**
+- All page headings (`h1`, `h2`) use `font-display font-bold`
+- Never use raw `emerald-*` or `gray-*` — use `primary-*` and `warm-*` tokens
+- Public layout uses `.card-warm` for auth forms
+- Body background uses `.bg-warm-gradient`, not flat color
+
 ## Key Environment Variables
 
 - `MULTI_TENANT` — enables multi-tenant mode (accounts created via signup flow)

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,1 +1,70 @@
 @import "tailwindcss";
+
+@theme {
+  /* ============================================
+   * MealSzn Design System
+   * ============================================
+   * Primary: Terracotta — warm, earthy, food-forward
+   * Accent:  Saffron/Golden — sunny, inviting CTAs
+   * Warm:    Warm neutrals — replaces cold grays
+   * ============================================ */
+
+  /* --- Typography --- */
+  --font-sans: "Nunito Sans", ui-sans-serif, system-ui, sans-serif;
+  --font-display: "Bitter", ui-serif, Georgia, serif;
+
+  /* --- Primary (Terracotta) --- */
+  --color-primary-50: #fdf5f0;
+  --color-primary-100: #fae8dd;
+  --color-primary-200: #f5ccaf;
+  --color-primary-300: #edaa7d;
+  --color-primary-400: #e28b52;
+  --color-primary-500: #d4722e;
+  --color-primary-600: #c2582a;
+  --color-primary-700: #a14722;
+  --color-primary-800: #7d381c;
+  --color-primary-900: #5c2b17;
+
+  /* --- Accent (Saffron) --- */
+  --color-accent-50: #fdf8eb;
+  --color-accent-100: #fbf0cc;
+  --color-accent-200: #f7e099;
+  --color-accent-300: #f0cb5f;
+  --color-accent-400: #e6b42e;
+  --color-accent-500: #d4972f;
+  --color-accent-600: #b87d1f;
+  --color-accent-700: #946018;
+  --color-accent-800: #6d4714;
+  --color-accent-900: #4a3010;
+
+  /* --- Warm Neutrals --- */
+  --color-warm-50: #fdfbf7;
+  --color-warm-100: #f5f0e8;
+  --color-warm-200: #e8dfd2;
+  --color-warm-300: #d4c8b8;
+  --color-warm-400: #b5a794;
+  --color-warm-500: #8b7355;
+  --color-warm-600: #6b5a42;
+  --color-warm-700: #504333;
+  --color-warm-800: #3d2b1f;
+  --color-warm-900: #2a1c13;
+}
+
+/* Warm body background gradient */
+.bg-warm-gradient {
+  background: linear-gradient(168deg, #fdfbf7 0%, #fae8dd 50%, #fff5eb 100%);
+}
+
+/* Public layout card glass effect */
+.card-warm {
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(8px);
+  box-shadow:
+    0 4px 24px rgba(93, 43, 23, 0.08),
+    0 1px 3px rgba(93, 43, 23, 0.04);
+}
+
+/* Navbar warm gradient */
+.nav-warm {
+  background: linear-gradient(135deg, #7d381c 0%, #a14722 40%, #c2582a 100%);
+}

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -3,9 +3,9 @@ module NavigationHelper
     active = controller_match.include?(controller_name)
 
     css = if active
-      "bg-emerald-700 text-white rounded-md px-3 py-2 text-sm font-medium"
+      "bg-primary-800 text-white rounded-md px-3 py-2 text-sm font-medium"
     else
-      "text-emerald-100 hover:bg-emerald-500 hover:text-white rounded-md px-3 py-2 text-sm font-medium"
+      "text-primary-100 hover:bg-primary-600 hover:text-white rounded-md px-3 py-2 text-sm font-medium"
     end
 
     link_to name, path, class: css

--- a/app/views/accounts/dashboards/show.html.erb
+++ b/app/views/accounts/dashboards/show.html.erb
@@ -2,8 +2,8 @@
 
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
   <div class="mb-8">
-    <h1 class="text-3xl font-bold text-gray-900">Welcome to <%= Current.account.name %></h1>
-    <p class="text-gray-600 mt-1">Manage your recipes and meal plans</p>
+    <h1 class="text-3xl font-display font-bold text-warm-900">Welcome to <%= Current.account.name %></h1>
+    <p class="text-warm-600 mt-1">Manage your recipes and meal plans</p>
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
@@ -11,15 +11,15 @@
     <div class="bg-white rounded-lg shadow p-6">
       <div class="flex items-center">
         <div class="flex-shrink-0">
-          <div class="w-12 h-12 bg-emerald-100 rounded-lg flex items-center justify-center">
-            <svg class="w-6 h-6 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div class="w-12 h-12 bg-primary-100 rounded-lg flex items-center justify-center">
+            <svg class="w-6 h-6 text-primary-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
             </svg>
           </div>
         </div>
         <div class="ml-4">
-          <p class="text-sm font-medium text-gray-500">Total Recipes</p>
-          <p class="text-2xl font-bold text-gray-900"><%= Current.account.recipes.count %></p>
+          <p class="text-sm font-medium text-warm-500">Total Recipes</p>
+          <p class="text-2xl font-display font-bold text-warm-900"><%= Current.account.recipes.count %></p>
         </div>
       </div>
     </div>
@@ -28,15 +28,15 @@
     <div class="bg-white rounded-lg shadow p-6">
       <div class="flex items-center">
         <div class="flex-shrink-0">
-          <div class="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center">
-            <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div class="w-12 h-12 bg-accent-100 rounded-lg flex items-center justify-center">
+            <svg class="w-6 h-6 text-accent-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"/>
             </svg>
           </div>
         </div>
         <div class="ml-4">
-          <p class="text-sm font-medium text-gray-500">Categories</p>
-          <p class="text-2xl font-bold text-gray-900"><%= Recipe.categories.keys.count %></p>
+          <p class="text-sm font-medium text-warm-500">Categories</p>
+          <p class="text-2xl font-display font-bold text-warm-900"><%= Recipe.categories.keys.count %></p>
         </div>
       </div>
     </div>
@@ -45,10 +45,10 @@
     <div class="bg-white rounded-lg shadow p-6">
       <div class="flex items-center justify-between">
         <div>
-          <p class="text-sm font-medium text-gray-500">Quick Actions</p>
-          <p class="text-lg font-semibold text-gray-900 mt-1">Add New Recipe</p>
+          <p class="text-sm font-medium text-warm-500">Quick Actions</p>
+          <p class="text-lg font-semibold text-warm-900 mt-1">Add New Recipe</p>
         </div>
-        <%= link_to new_recipe_path, class: "bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700 transition-colors" do %>
+        <%= link_to new_recipe_path, class: "bg-primary-600 text-white px-4 py-2 rounded-lg hover:bg-primary-700 transition-colors" do %>
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
           </svg>
@@ -59,52 +59,52 @@
 
   <!-- Current Meal Plan -->
   <div class="bg-white rounded-lg shadow mb-8">
-    <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
-      <h2 class="text-lg font-semibold text-gray-900">Current Meal Plan</h2>
-      <%= link_to "All Plans", meal_plans_path, class: "text-emerald-600 hover:text-emerald-700 text-sm font-medium" %>
+    <div class="px-6 py-4 border-b border-warm-200 flex justify-between items-center">
+      <h2 class="text-lg font-semibold text-warm-900">Current Meal Plan</h2>
+      <%= link_to "All Plans", meal_plans_path, class: "text-primary-600 hover:text-primary-700 text-sm font-medium" %>
     </div>
 
     <% if @current_meal_plan %>
       <div class="p-6">
         <div class="flex justify-between items-start mb-4">
           <div>
-            <h3 class="text-lg font-semibold text-gray-900"><%= @current_meal_plan.name %></h3>
-            <p class="text-sm text-gray-500">
+            <h3 class="text-lg font-semibold text-warm-900"><%= @current_meal_plan.name %></h3>
+            <p class="text-sm text-warm-500">
               <%= @current_meal_plan.start_date.strftime("%b %-d") %> - <%= @current_meal_plan.end_date.strftime("%b %-d, %Y") %>
             </p>
           </div>
-          <%= link_to "View Plan", meal_plan_path(@current_meal_plan), class: "bg-emerald-600 text-white px-3 py-1.5 rounded-lg hover:bg-emerald-700 transition-colors text-sm font-medium" %>
+          <%= link_to "View Plan", meal_plan_path(@current_meal_plan), class: "bg-primary-600 text-white px-3 py-1.5 rounded-lg hover:bg-primary-700 transition-colors text-sm font-medium" %>
         </div>
 
         <% today = @current_meal_plan.days.find { |d| d.date == Date.current } %>
         <% if today && today.meals.any? %>
-          <h4 class="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-2">Today's Meals</h4>
+          <h4 class="text-sm font-semibold text-warm-500 uppercase tracking-wider mb-2">Today's Meals</h4>
           <ul class="space-y-1">
             <% today.meals.each do |meal| %>
               <li class="flex items-center justify-between text-sm">
                 <span>
-                  <span class="text-gray-500 capitalize"><%= meal.meal_type %>:</span>
-                  <%= link_to meal.recipe.title, recipe_path(meal.recipe), class: "text-gray-900 hover:text-emerald-600" %>
+                  <span class="text-warm-500 capitalize"><%= meal.meal_type %>:</span>
+                  <%= link_to meal.recipe.title, recipe_path(meal.recipe), class: "text-warm-900 hover:text-primary-600" %>
                 </span>
                 <% if meal.recipe.nutrition_data %>
-                  <span class="text-gray-400"><%= meal.calories %> cal</span>
+                  <span class="text-warm-400"><%= meal.calories %> cal</span>
                 <% end %>
               </li>
             <% end %>
           </ul>
         <% else %>
-          <p class="text-sm text-gray-400 italic">No meals planned for today.</p>
+          <p class="text-sm text-warm-400 italic">No meals planned for today.</p>
         <% end %>
       </div>
     <% else %>
       <div class="px-6 py-8 text-center">
-        <svg class="mx-auto h-10 w-10 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg class="mx-auto h-10 w-10 text-warm-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
         </svg>
-        <h3 class="mt-2 text-sm font-medium text-gray-900">No active meal plan</h3>
-        <p class="mt-1 text-sm text-gray-500">Create a meal plan to organize your weekly meals.</p>
+        <h3 class="mt-2 text-sm font-medium text-warm-900">No active meal plan</h3>
+        <p class="mt-1 text-sm text-warm-500">Create a meal plan to organize your weekly meals.</p>
         <div class="mt-4">
-          <%= link_to "Create Meal Plan", new_meal_plan_path, class: "bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700 transition-colors text-sm" %>
+          <%= link_to "Create Meal Plan", new_meal_plan_path, class: "bg-primary-600 text-white px-4 py-2 rounded-lg hover:bg-primary-700 transition-colors text-sm" %>
         </div>
       </div>
     <% end %>
@@ -112,20 +112,20 @@
 
   <!-- Recent Recipes -->
   <div class="bg-white rounded-lg shadow">
-    <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
-      <h2 class="text-lg font-semibold text-gray-900">Recent Recipes</h2>
-      <%= link_to "View All", recipes_path, class: "text-emerald-600 hover:text-emerald-700 text-sm font-medium" %>
+    <div class="px-6 py-4 border-b border-warm-200 flex justify-between items-center">
+      <h2 class="text-lg font-semibold text-warm-900">Recent Recipes</h2>
+      <%= link_to "View All", recipes_path, class: "text-primary-600 hover:text-primary-700 text-sm font-medium" %>
     </div>
 
     <% if @recent_recipes&.any? %>
-      <ul class="divide-y divide-gray-200">
+      <ul class="divide-y divide-warm-200">
         <% @recent_recipes.each do |recipe| %>
-          <li class="px-6 py-4 hover:bg-gray-50">
+          <li class="px-6 py-4 hover:bg-warm-50">
             <%= link_to recipe_path(recipe), class: "flex items-center justify-between" do %>
               <div>
-                <p class="font-medium text-gray-900"><%= recipe.title %></p>
-                <p class="text-sm text-gray-500">
-                  <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800">
+                <p class="font-medium text-warm-900"><%= recipe.title %></p>
+                <p class="text-sm text-warm-500">
+                  <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-warm-100 text-warm-800">
                     <%= recipe.category.titleize %>
                   </span>
                   <% if recipe.nutrition_data %>
@@ -133,7 +133,7 @@
                   <% end %>
                 </p>
               </div>
-              <svg class="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-warm-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
               </svg>
             <% end %>
@@ -142,13 +142,13 @@
       </ul>
     <% else %>
       <div class="px-6 py-12 text-center">
-        <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg class="mx-auto h-12 w-12 text-warm-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
         </svg>
-        <h3 class="mt-2 text-sm font-medium text-gray-900">No recipes yet</h3>
-        <p class="mt-1 text-sm text-gray-500">Get started by adding your first recipe.</p>
+        <h3 class="mt-2 text-sm font-medium text-warm-900">No recipes yet</h3>
+        <p class="mt-1 text-sm text-warm-500">Get started by adding your first recipe.</p>
         <div class="mt-6">
-          <%= link_to "Add Recipe", new_recipe_path, class: "bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700 transition-colors" %>
+          <%= link_to "Add Recipe", new_recipe_path, class: "bg-primary-600 text-white px-4 py-2 rounded-lg hover:bg-primary-700 transition-colors" %>
         </div>
       </div>
     <% end %>

--- a/app/views/accounts/dietary_profiles/_form.html.erb
+++ b/app/views/accounts/dietary_profiles/_form.html.erb
@@ -12,35 +12,35 @@
     <% end %>
 
     <div>
-      <%= f.label :name, class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.text_field :name, class: "w-full rounded-lg border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500", placeholder: 'e.g., "Dad", "Mom", "Timmy"' %>
+      <%= f.label :name, class: "block text-sm font-medium text-warm-700 mb-1" %>
+      <%= f.text_field :name, class: "w-full rounded-lg border-warm-300 shadow-sm focus:border-primary-500 focus:ring-primary-500", placeholder: 'e.g., "Dad", "Mom", "Timmy"' %>
     </div>
 
     <div>
-      <%= f.label :diet_name, "Diet", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.select :diet_name, DietRegistry.diet_names.map { |n| [n, n] }, { include_blank: "No specific diet", selected: dietary_profile.diet_name }, class: "w-full rounded-lg border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500", data: { diet_preview_target: "dietSelect", action: "change->diet-preview#update" } %>
+      <%= f.label :diet_name, "Diet", class: "block text-sm font-medium text-warm-700 mb-1" %>
+      <%= f.select :diet_name, DietRegistry.diet_names.map { |n| [n, n] }, { include_blank: "No specific diet", selected: dietary_profile.diet_name }, class: "w-full rounded-lg border-warm-300 shadow-sm focus:border-primary-500 focus:ring-primary-500", data: { diet_preview_target: "dietSelect", action: "change->diet-preview#update" } %>
     </div>
 
     <div>
-      <%= f.label :daily_calories_target, "Daily Calorie Target", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.number_field :daily_calories_target, class: "w-full rounded-lg border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500", placeholder: "e.g., 2000", min: 1, data: { diet_preview_target: "caloriesInput", action: "input->diet-preview#update" } %>
+      <%= f.label :daily_calories_target, "Daily Calorie Target", class: "block text-sm font-medium text-warm-700 mb-1" %>
+      <%= f.number_field :daily_calories_target, class: "w-full rounded-lg border-warm-300 shadow-sm focus:border-primary-500 focus:ring-primary-500", placeholder: "e.g., 2000", min: 1, data: { diet_preview_target: "caloriesInput", action: "input->diet-preview#update" } %>
     </div>
 
     <div data-diet-preview-target="preview" class="<%= 'hidden' unless dietary_profile.macro_targets %>">
       <% if (targets = dietary_profile.macro_targets) %>
-        <div class="bg-gray-50 rounded-lg p-4">
-          <h4 class="text-sm font-medium text-gray-700 mb-2">Daily Macro Targets</h4>
+        <div class="bg-warm-50 rounded-lg p-4">
+          <h4 class="text-sm font-medium text-warm-700 mb-2">Daily Macro Targets</h4>
           <div class="grid grid-cols-3 gap-4 text-sm">
             <div>
-              <span class="text-gray-500">Fat:</span>
+              <span class="text-warm-500">Fat:</span>
               <span class="font-medium" data-diet-preview-target="fatValue"><%= targets[:fat_g] %>g</span>
             </div>
             <div>
-              <span class="text-gray-500">Protein:</span>
+              <span class="text-warm-500">Protein:</span>
               <span class="font-medium" data-diet-preview-target="proteinValue"><%= targets[:protein_g] %>g</span>
             </div>
             <div>
-              <span class="text-gray-500">Carbs:</span>
+              <span class="text-warm-500">Carbs:</span>
               <span class="font-medium" data-diet-preview-target="carbsValue"><%= targets[:carbs_g] %>g</span>
             </div>
           </div>
@@ -49,14 +49,14 @@
     </div>
 
     <div>
-      <%= f.label :user_id, "Link to User Account (optional)", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.select :user_id, Current.account.users.active.map { |u| [u.name, u.id] }, { include_blank: "No linked user (e.g., child)" }, class: "w-full rounded-lg border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500" %>
-      <p class="mt-1 text-xs text-gray-500">Link to a user account for members who log in. Leave blank for family members without accounts (like kids).</p>
+      <%= f.label :user_id, "Link to User Account (optional)", class: "block text-sm font-medium text-warm-700 mb-1" %>
+      <%= f.select :user_id, Current.account.users.active.map { |u| [u.name, u.id] }, { include_blank: "No linked user (e.g., child)" }, class: "w-full rounded-lg border-warm-300 shadow-sm focus:border-primary-500 focus:ring-primary-500" %>
+      <p class="mt-1 text-xs text-warm-500">Link to a user account for members who log in. Leave blank for family members without accounts (like kids).</p>
     </div>
 
-    <div class="flex justify-end gap-3 pt-4 border-t border-gray-200">
-      <%= link_to "Cancel", dietary_profiles_path, class: "px-4 py-2 text-gray-700 hover:text-gray-900 text-sm font-medium" %>
-      <%= f.submit dietary_profile.persisted? ? "Update Profile" : "Create Profile", class: "bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700 transition-colors text-sm font-medium cursor-pointer" %>
+    <div class="flex justify-end gap-3 pt-4 border-t border-warm-200">
+      <%= link_to "Cancel", dietary_profiles_path, class: "px-4 py-2 text-warm-700 hover:text-warm-900 text-sm font-medium" %>
+      <%= f.submit dietary_profile.persisted? ? "Update Profile" : "Create Profile", class: "bg-primary-600 text-white px-4 py-2 rounded-lg hover:bg-primary-700 transition-colors text-sm font-medium cursor-pointer" %>
     </div>
   <% end %>
 </div>

--- a/app/views/accounts/dietary_profiles/edit.html.erb
+++ b/app/views/accounts/dietary_profiles/edit.html.erb
@@ -2,10 +2,10 @@
 
 <div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
   <div class="mb-6">
-    <%= link_to "&larr; Back to Dietary Profiles".html_safe, dietary_profiles_path, class: "text-emerald-600 hover:text-emerald-700 text-sm font-medium" %>
+    <%= link_to "&larr; Back to Dietary Profiles".html_safe, dietary_profiles_path, class: "text-primary-600 hover:text-primary-700 text-sm font-medium" %>
   </div>
 
-  <h1 class="text-3xl font-bold text-gray-900 mb-6">Edit Dietary Profile</h1>
+  <h1 class="text-3xl font-display font-bold text-warm-900 mb-6">Edit Dietary Profile</h1>
 
   <%= render "form", dietary_profile: @dietary_profile %>
 </div>

--- a/app/views/accounts/dietary_profiles/index.html.erb
+++ b/app/views/accounts/dietary_profiles/index.html.erb
@@ -2,35 +2,35 @@
 
 <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
   <div class="mb-6">
-    <%= link_to "&larr; Back to Settings".html_safe, settings_path, class: "text-emerald-600 hover:text-emerald-700 text-sm font-medium" %>
+    <%= link_to "&larr; Back to Settings".html_safe, settings_path, class: "text-primary-600 hover:text-primary-700 text-sm font-medium" %>
   </div>
 
   <div class="flex justify-between items-center mb-6">
-    <h1 class="text-3xl font-bold text-gray-900">Dietary Profiles</h1>
-    <%= link_to "New Profile", new_dietary_profile_path, class: "bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700 transition-colors text-sm font-medium" %>
+    <h1 class="text-3xl font-display font-bold text-warm-900">Dietary Profiles</h1>
+    <%= link_to "New Profile", new_dietary_profile_path, class: "bg-primary-600 text-white px-4 py-2 rounded-lg hover:bg-primary-700 transition-colors text-sm font-medium" %>
   </div>
 
   <% if @dietary_profiles.any? %>
     <div class="bg-white rounded-lg shadow overflow-hidden">
-      <table class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50">
+      <table class="min-w-full divide-y divide-warm-200">
+        <thead class="bg-warm-50">
           <tr>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Diet</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Daily Calories</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Linked User</th>
-            <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-warm-500 uppercase tracking-wider">Name</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-warm-500 uppercase tracking-wider">Diet</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-warm-500 uppercase tracking-wider">Daily Calories</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-warm-500 uppercase tracking-wider">Linked User</th>
+            <th class="px-6 py-3 text-right text-xs font-medium text-warm-500 uppercase tracking-wider">Actions</th>
           </tr>
         </thead>
-        <tbody class="bg-white divide-y divide-gray-200">
+        <tbody class="bg-white divide-y divide-warm-200">
           <% @dietary_profiles.each do |profile| %>
             <tr>
-              <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"><%= profile.name %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"><%= profile.diet_name.presence || "None" %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"><%= profile.daily_calories_target ? "#{profile.daily_calories_target} cal" : "Not set" %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"><%= profile.user&.name || "—" %></td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-warm-900"><%= profile.name %></td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-warm-500"><%= profile.diet_name.presence || "None" %></td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-warm-500"><%= profile.daily_calories_target ? "#{profile.daily_calories_target} cal" : "Not set" %></td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-warm-500"><%= profile.user&.name || "—" %></td>
               <td class="px-6 py-4 whitespace-nowrap text-right text-sm">
-                <%= link_to "Edit", edit_dietary_profile_path(profile), class: "text-emerald-600 hover:text-emerald-700 font-medium mr-3" %>
+                <%= link_to "Edit", edit_dietary_profile_path(profile), class: "text-primary-600 hover:text-primary-700 font-medium mr-3" %>
                 <%= button_to "Remove", dietary_profile_path(profile), method: :delete, class: "text-red-600 hover:text-red-700 font-medium", data: { turbo_confirm: "Remove this dietary profile?" } %>
               </td>
             </tr>
@@ -40,8 +40,8 @@
     </div>
   <% else %>
     <div class="bg-white rounded-lg shadow px-6 py-12 text-center">
-      <p class="text-gray-500 mb-4">No dietary profiles yet. Create profiles for your family members to track individual nutrition goals.</p>
-      <%= link_to "Create First Profile", new_dietary_profile_path, class: "text-emerald-600 hover:text-emerald-700 font-medium" %>
+      <p class="text-warm-500 mb-4">No dietary profiles yet. Create profiles for your family members to track individual nutrition goals.</p>
+      <%= link_to "Create First Profile", new_dietary_profile_path, class: "text-primary-600 hover:text-primary-700 font-medium" %>
     </div>
   <% end %>
 </div>

--- a/app/views/accounts/dietary_profiles/new.html.erb
+++ b/app/views/accounts/dietary_profiles/new.html.erb
@@ -2,10 +2,10 @@
 
 <div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
   <div class="mb-6">
-    <%= link_to "&larr; Back to Dietary Profiles".html_safe, dietary_profiles_path, class: "text-emerald-600 hover:text-emerald-700 text-sm font-medium" %>
+    <%= link_to "&larr; Back to Dietary Profiles".html_safe, dietary_profiles_path, class: "text-primary-600 hover:text-primary-700 text-sm font-medium" %>
   </div>
 
-  <h1 class="text-3xl font-bold text-gray-900 mb-6">New Dietary Profile</h1>
+  <h1 class="text-3xl font-display font-bold text-warm-900 mb-6">New Dietary Profile</h1>
 
   <%= render "form", dietary_profile: @dietary_profile %>
 </div>

--- a/app/views/accounts/meal_plans/_add_to_meal_plan_modal.html.erb
+++ b/app/views/accounts/meal_plans/_add_to_meal_plan_modal.html.erb
@@ -1,17 +1,17 @@
 <div>
   <div data-add-to-meal-plan-target="container" class="hidden fixed inset-0 z-50 overflow-y-auto" data-action="keydown.esc->add-to-meal-plan#close">
     <div class="flex items-center justify-center min-h-screen px-4">
-      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" data-action="click->add-to-meal-plan#close"></div>
+      <div class="fixed inset-0 bg-warm-500 bg-opacity-75 transition-opacity" data-action="click->add-to-meal-plan#close"></div>
 
       <div class="relative bg-white rounded-lg shadow-xl max-w-md w-full p-6 z-10">
-        <h3 class="text-lg font-semibold text-gray-900 mb-4">Add to Meal Plan</h3>
+        <h3 class="text-lg font-semibold text-warm-900 mb-4">Add to Meal Plan</h3>
 
         <div data-add-to-meal-plan-target="message" class="hidden mb-4 p-3 rounded-lg text-sm"></div>
 
         <div data-add-to-meal-plan-target="step1" class="space-y-4">
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Select Meal Plan</label>
-            <select data-add-to-meal-plan-target="planSelect" data-action="change->add-to-meal-plan#planSelected" class="w-full rounded-lg border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
+            <label class="block text-sm font-medium text-warm-700 mb-1">Select Meal Plan</label>
+            <select data-add-to-meal-plan-target="planSelect" data-action="change->add-to-meal-plan#planSelected" class="w-full rounded-lg border-warm-300 shadow-sm focus:border-primary-500 focus:ring-primary-500">
               <option value="">Choose a meal plan...</option>
               <% meal_plans.each do |plan| %>
                 <option value="<%= plan.id %>" data-days='<%= plan.days.order(:day_number).map { |d| { id: d.id, label: "Day #{d.day_number} - #{d.date.strftime('%A, %b %-d')}" } }.to_json %>'>
@@ -24,14 +24,14 @@
 
         <div data-add-to-meal-plan-target="step2" class="hidden space-y-4 mt-4">
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Day</label>
-            <select data-add-to-meal-plan-target="daySelect" class="w-full rounded-lg border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
+            <label class="block text-sm font-medium text-warm-700 mb-1">Day</label>
+            <select data-add-to-meal-plan-target="daySelect" class="w-full rounded-lg border-warm-300 shadow-sm focus:border-primary-500 focus:ring-primary-500">
             </select>
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Meal Type</label>
-            <select data-add-to-meal-plan-target="mealType" class="w-full rounded-lg border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
+            <label class="block text-sm font-medium text-warm-700 mb-1">Meal Type</label>
+            <select data-add-to-meal-plan-target="mealType" class="w-full rounded-lg border-warm-300 shadow-sm focus:border-primary-500 focus:ring-primary-500">
               <option value="breakfast">Breakfast</option>
               <option value="lunch">Lunch</option>
               <option value="dinner">Dinner</option>
@@ -40,13 +40,13 @@
           </div>
 
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Servings</label>
-            <input type="number" data-add-to-meal-plan-target="servings" value="1" min="0.25" step="0.25" class="w-full rounded-lg border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
+            <label class="block text-sm font-medium text-warm-700 mb-1">Servings</label>
+            <input type="number" data-add-to-meal-plan-target="servings" value="1" min="0.25" step="0.25" class="w-full rounded-lg border-warm-300 shadow-sm focus:border-primary-500 focus:ring-primary-500">
           </div>
 
           <div class="flex justify-end gap-3 pt-4">
-            <button type="button" data-action="add-to-meal-plan#close" class="px-4 py-2 text-gray-700 hover:text-gray-900 text-sm font-medium">Cancel</button>
-            <button type="button" data-action="add-to-meal-plan#submit" data-add-to-meal-plan-target="submitBtn" class="bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700 transition-colors text-sm font-medium">Add Meal</button>
+            <button type="button" data-action="add-to-meal-plan#close" class="px-4 py-2 text-warm-700 hover:text-warm-900 text-sm font-medium">Cancel</button>
+            <button type="button" data-action="add-to-meal-plan#submit" data-add-to-meal-plan-target="submitBtn" class="bg-primary-600 text-white px-4 py-2 rounded-lg hover:bg-primary-700 transition-colors text-sm font-medium">Add Meal</button>
           </div>
         </div>
       </div>

--- a/app/views/accounts/meal_plans/_day_card.html.erb
+++ b/app/views/accounts/meal_plans/_day_card.html.erb
@@ -1,29 +1,29 @@
 <div class="bg-white rounded-lg shadow">
-  <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
+  <div class="px-6 py-4 border-b border-warm-200 flex justify-between items-center">
     <div>
-      <h3 class="text-lg font-semibold text-gray-900">
+      <h3 class="text-lg font-semibold text-warm-900">
         Day <%= day.day_number %> - <%= day.date.strftime("%A, %b %-d") %>
       </h3>
     </div>
-    <div class="text-sm text-gray-500">
+    <div class="text-sm text-warm-500">
       <% total = day.meals.sum { |m| m.recipe.nutrition_data&.calories.to_i * m.servings } %>
       <%= total.round %> cal total
     </div>
   </div>
 
-  <div class="divide-y divide-gray-100">
+  <div class="divide-y divide-warm-100">
     <% %w[breakfast lunch dinner snack].each do |meal_type| %>
       <% meals = day.meals.select { |m| m.meal_type == meal_type } %>
       <% if meals.any? %>
         <div class="px-6 py-3">
-          <h4 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2"><%= meal_type.titleize %></h4>
+          <h4 class="text-xs font-semibold text-warm-500 uppercase tracking-wider mb-2"><%= meal_type.titleize %></h4>
           <% meals.each do |meal| %>
             <div class="flex items-center justify-between py-1">
               <div class="flex items-center gap-3">
-                <%= link_to meal.recipe.title, recipe_path(meal.recipe), class: "text-gray-900 hover:text-emerald-600 font-medium" %>
-                <span class="text-sm text-gray-500"><%= meal.servings.to_f == meal.servings.to_i.to_f ? meal.servings.to_i : meal.servings %> serving<%= meal.servings == 1 ? '' : 's' %></span>
+                <%= link_to meal.recipe.title, recipe_path(meal.recipe), class: "text-warm-900 hover:text-primary-600 font-medium" %>
+                <span class="text-sm text-warm-500"><%= meal.servings.to_f == meal.servings.to_i.to_f ? meal.servings.to_i : meal.servings %> serving<%= meal.servings == 1 ? '' : 's' %></span>
                 <% if meal.recipe.nutrition_data %>
-                  <span class="text-sm text-gray-400"><%= meal.calories %> cal</span>
+                  <span class="text-sm text-warm-400"><%= meal.calories %> cal</span>
                 <% end %>
               </div>
               <%= button_to meal_plan_meal_path(meal_plan, meal), method: :delete, class: "text-red-400 hover:text-red-600", data: { turbo_confirm: "Remove this meal?" } do %>
@@ -37,13 +37,13 @@
                 <% participants.each_with_index do |participant, p_idx| %>
                   <% portion = participant.portions.find { |pt| pt.meal_plan_meal_id == meal.id } %>
                   <% if portion %>
-                    <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-gray-100" data-controller="portion-edit" data-portion-edit-url-value="<%= meal_plan_portion_path(meal_plan, portion) %>">
+                    <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-warm-100" data-controller="portion-edit" data-portion-edit-url-value="<%= meal_plan_portion_path(meal_plan, portion) %>">
                       <span class="inline-block w-2 h-2 rounded-full" style="background-color: <%= participant_color(p_idx) %>"></span>
-                      <span class="text-gray-700"><%= participant.name %></span>
-                      <button type="button" class="font-medium text-gray-900 hover:text-emerald-600 cursor-pointer" data-action="click->portion-edit#edit" data-portion-edit-target="display">
+                      <span class="text-warm-700"><%= participant.name %></span>
+                      <button type="button" class="font-medium text-warm-900 hover:text-primary-600 cursor-pointer" data-action="click->portion-edit#edit" data-portion-edit-target="display">
                         <%= portion.servings.to_f == portion.servings.to_i.to_f ? portion.servings.to_i : portion.servings %>
                       </button>
-                      <input type="number" step="0.25" min="0.25" max="10" value="<%= portion.servings %>" class="hidden w-16 text-xs border border-gray-300 rounded px-1 py-0" data-portion-edit-target="input" data-action="blur->portion-edit#save keydown.enter->portion-edit#save keydown.escape->portion-edit#cancel">
+                      <input type="number" step="0.25" min="0.25" max="10" value="<%= portion.servings %>" class="hidden w-16 text-xs border border-warm-300 rounded px-1 py-0" data-portion-edit-target="input" data-action="blur->portion-edit#save keydown.enter->portion-edit#save keydown.escape->portion-edit#cancel">
                     </span>
                   <% end %>
                 <% end %>
@@ -55,20 +55,20 @@
     <% end %>
 
     <% if day.meals.empty? %>
-      <div class="px-6 py-4 text-sm text-gray-400 italic">No meals planned for this day.</div>
+      <div class="px-6 py-4 text-sm text-warm-400 italic">No meals planned for this day.</div>
     <% end %>
   </div>
 
   <% if defined?(participants) && participants&.any? && day.meals.any? %>
-    <div class="px-6 py-4 border-t border-gray-200 bg-gray-50 rounded-b-lg">
-      <h4 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">Daily Macros by Participant</h4>
+    <div class="px-6 py-4 border-t border-warm-200 bg-warm-50 rounded-b-lg">
+      <h4 class="text-xs font-semibold text-warm-500 uppercase tracking-wider mb-3">Daily Macros by Participant</h4>
       <div class="space-y-2">
         <% participants.each_with_index do |participant, p_idx| %>
           <% totals = participant.daily_totals_for(day) %>
           <% targets = participant.macro_targets %>
           <div class="flex items-center gap-3 text-sm">
             <span class="inline-block w-3 h-3 rounded-full shrink-0" style="background-color: <%= participant_color(p_idx) %>"></span>
-            <span class="font-medium text-gray-900 w-20 truncate"><%= participant.name %></span>
+            <span class="font-medium text-warm-900 w-20 truncate"><%= participant.name %></span>
             <div class="flex gap-4 text-xs">
               <span class="<%= macro_status_class(totals[:calories], targets&.dig(:calories)) %>">
                 Cal: <%= totals[:calories].round %><%= "/#{targets[:calories]}" if targets&.dig(:calories) %>

--- a/app/views/accounts/meal_plans/_duplicate_modal.html.erb
+++ b/app/views/accounts/meal_plans/_duplicate_modal.html.erb
@@ -1,31 +1,31 @@
 <div data-controller="modal">
   <div data-modal-target="container" class="hidden fixed inset-0 z-50 overflow-y-auto" data-action="keydown.esc->modal#close">
     <div class="flex items-center justify-center min-h-screen px-4">
-      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" data-action="click->modal#close"></div>
+      <div class="fixed inset-0 bg-warm-500 bg-opacity-75 transition-opacity" data-action="click->modal#close"></div>
 
       <div class="relative bg-white rounded-lg shadow-xl max-w-md w-full p-6 z-10">
-        <h3 class="text-lg font-semibold text-gray-900 mb-4">Duplicate Meal Plan</h3>
+        <h3 class="text-lg font-semibold text-warm-900 mb-4">Duplicate Meal Plan</h3>
 
         <%= form_with url: duplicate_meal_plan_path(meal_plan), method: :post, class: "space-y-4" do |f| %>
           <div>
-            <%= f.label :name, class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= f.text_field :name, value: "Copy of #{meal_plan.name}", class: "w-full rounded-lg border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500" %>
+            <%= f.label :name, class: "block text-sm font-medium text-warm-700 mb-1" %>
+            <%= f.text_field :name, value: "Copy of #{meal_plan.name}", class: "w-full rounded-lg border-warm-300 shadow-sm focus:border-primary-500 focus:ring-primary-500" %>
           </div>
 
           <div class="grid grid-cols-2 gap-4">
             <div>
-              <%= f.label :start_date, class: "block text-sm font-medium text-gray-700 mb-1" %>
-              <%= f.date_field :start_date, value: Date.current.beginning_of_week + 7.days, class: "w-full rounded-lg border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500" %>
+              <%= f.label :start_date, class: "block text-sm font-medium text-warm-700 mb-1" %>
+              <%= f.date_field :start_date, value: Date.current.beginning_of_week + 7.days, class: "w-full rounded-lg border-warm-300 shadow-sm focus:border-primary-500 focus:ring-primary-500" %>
             </div>
             <div>
-              <%= f.label :end_date, class: "block text-sm font-medium text-gray-700 mb-1" %>
-              <%= f.date_field :end_date, value: Date.current.beginning_of_week + 13.days, class: "w-full rounded-lg border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500" %>
+              <%= f.label :end_date, class: "block text-sm font-medium text-warm-700 mb-1" %>
+              <%= f.date_field :end_date, value: Date.current.beginning_of_week + 13.days, class: "w-full rounded-lg border-warm-300 shadow-sm focus:border-primary-500 focus:ring-primary-500" %>
             </div>
           </div>
 
           <div class="flex justify-end gap-3 pt-4">
-            <button type="button" data-action="modal#close" class="px-4 py-2 text-gray-700 hover:text-gray-900 text-sm font-medium">Cancel</button>
-            <%= f.submit "Duplicate", class: "bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700 transition-colors text-sm font-medium cursor-pointer" %>
+            <button type="button" data-action="modal#close" class="px-4 py-2 text-warm-700 hover:text-warm-900 text-sm font-medium">Cancel</button>
+            <%= f.submit "Duplicate", class: "bg-primary-600 text-white px-4 py-2 rounded-lg hover:bg-primary-700 transition-colors text-sm font-medium cursor-pointer" %>
           </div>
         <% end %>
       </div>

--- a/app/views/accounts/meal_plans/_form.html.erb
+++ b/app/views/accounts/meal_plans/_form.html.erb
@@ -12,22 +12,22 @@
     <% end %>
 
     <div>
-      <%= f.label :name, class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.text_field :name, class: "w-full rounded-lg border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500", placeholder: "e.g., Week of Feb 10, 2026", data: { meal_plan_form_target: "name" } %>
+      <%= f.label :name, class: "block text-sm font-medium text-warm-700 mb-1" %>
+      <%= f.text_field :name, class: "w-full rounded-lg border-warm-300 shadow-sm focus:border-primary-500 focus:ring-primary-500", placeholder: "e.g., Week of Feb 10, 2026", data: { meal_plan_form_target: "name" } %>
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div>
-        <%= f.label :start_date, class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.date_field :start_date, class: "w-full rounded-lg border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500", data: { meal_plan_form_target: "startDate", action: "change->meal-plan-form#dateChanged" } %>
+        <%= f.label :start_date, class: "block text-sm font-medium text-warm-700 mb-1" %>
+        <%= f.date_field :start_date, class: "w-full rounded-lg border-warm-300 shadow-sm focus:border-primary-500 focus:ring-primary-500", data: { meal_plan_form_target: "startDate", action: "change->meal-plan-form#dateChanged" } %>
       </div>
       <div>
-        <%= f.label :end_date, class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.date_field :end_date, class: "w-full rounded-lg border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500", data: { meal_plan_form_target: "endDate", action: "change->meal-plan-form#dateChanged" } %>
+        <%= f.label :end_date, class: "block text-sm font-medium text-warm-700 mb-1" %>
+        <%= f.date_field :end_date, class: "w-full rounded-lg border-warm-300 shadow-sm focus:border-primary-500 focus:ring-primary-500", data: { meal_plan_form_target: "endDate", action: "change->meal-plan-form#dateChanged" } %>
       </div>
     </div>
 
-    <p class="text-sm text-gray-500" data-meal-plan-form-target="duration">
+    <p class="text-sm text-warm-500" data-meal-plan-form-target="duration">
       <% if meal_plan.start_date && meal_plan.end_date %>
         Duration: <%= meal_plan.duration_days %> days
       <% end %>
@@ -35,16 +35,16 @@
 
     <% if !meal_plan.persisted? && @available_profiles&.any? %>
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-2">Participants</label>
-        <p class="text-xs text-gray-500 mb-3">Select family members who will eat from this meal plan.</p>
+        <label class="block text-sm font-medium text-warm-700 mb-2">Participants</label>
+        <p class="text-xs text-warm-500 mb-3">Select family members who will eat from this meal plan.</p>
         <div class="space-y-2">
           <% @available_profiles.each do |profile| %>
-            <label class="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-50 cursor-pointer">
-              <input type="checkbox" name="dietary_profile_ids[]" value="<%= profile.id %>" class="rounded text-emerald-600 focus:ring-emerald-500">
+            <label class="flex items-center gap-3 p-2 rounded-lg hover:bg-warm-50 cursor-pointer">
+              <input type="checkbox" name="dietary_profile_ids[]" value="<%= profile.id %>" class="rounded text-primary-600 focus:ring-primary-500">
               <div>
-                <span class="text-sm font-medium text-gray-900"><%= profile.name %></span>
+                <span class="text-sm font-medium text-warm-900"><%= profile.name %></span>
                 <% if profile.diet_name.present? || profile.daily_calories_target %>
-                  <span class="text-xs text-gray-500 ml-1">
+                  <span class="text-xs text-warm-500 ml-1">
                     (<%= [profile.diet_name, profile.daily_calories_target ? "#{profile.daily_calories_target} cal" : nil].compact.join(" · ") %>)
                   </span>
                 <% end %>
@@ -55,9 +55,9 @@
       </div>
     <% end %>
 
-    <div class="flex justify-end gap-3 pt-4 border-t border-gray-200">
-      <%= link_to "Cancel", meal_plan.persisted? ? meal_plan_path(meal_plan) : meal_plans_path, class: "px-4 py-2 text-gray-700 hover:text-gray-900 text-sm font-medium" %>
-      <%= f.submit meal_plan.persisted? ? "Update Meal Plan" : "Create Meal Plan", class: "bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700 transition-colors text-sm font-medium cursor-pointer" %>
+    <div class="flex justify-end gap-3 pt-4 border-t border-warm-200">
+      <%= link_to "Cancel", meal_plan.persisted? ? meal_plan_path(meal_plan) : meal_plans_path, class: "px-4 py-2 text-warm-700 hover:text-warm-900 text-sm font-medium" %>
+      <%= f.submit meal_plan.persisted? ? "Update Meal Plan" : "Create Meal Plan", class: "bg-primary-600 text-white px-4 py-2 rounded-lg hover:bg-primary-700 transition-colors text-sm font-medium cursor-pointer" %>
     </div>
   <% end %>
 </div>

--- a/app/views/accounts/meal_plans/_meal_plan_card.html.erb
+++ b/app/views/accounts/meal_plans/_meal_plan_card.html.erb
@@ -1,14 +1,14 @@
-<%= link_to meal_plan_path(plan), class: "block bg-white rounded-lg shadow hover:shadow-md transition-shadow p-6 #{highlight ? 'ring-2 ring-emerald-500' : ''}" do %>
+<%= link_to meal_plan_path(plan), class: "block bg-white rounded-lg shadow hover:shadow-md transition-shadow p-6 #{highlight ? 'ring-2 ring-primary-500' : ''}" do %>
   <div class="flex justify-between items-start mb-2">
-    <h3 class="text-lg font-semibold text-gray-900"><%= plan.name || "Untitled Plan" %></h3>
+    <h3 class="text-lg font-semibold text-warm-900"><%= plan.name || "Untitled Plan" %></h3>
     <% if plan.current? %>
-      <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-emerald-100 text-emerald-800">Active</span>
+      <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary-100 text-primary-800">Active</span>
     <% end %>
   </div>
-  <p class="text-sm text-gray-500 mb-3">
+  <p class="text-sm text-warm-500 mb-3">
     <%= plan.start_date.strftime("%b %-d") %> - <%= plan.end_date.strftime("%b %-d, %Y") %>
   </p>
-  <div class="flex items-center gap-4 text-sm text-gray-600">
+  <div class="flex items-center gap-4 text-sm text-warm-600">
     <span><%= plan.duration_days %> days</span>
     <span><%= plan.days.sum { |d| d.meals.size } %> meals</span>
     <% if plan.daily_calories_target %>

--- a/app/views/accounts/meal_plans/edit.html.erb
+++ b/app/views/accounts/meal_plans/edit.html.erb
@@ -2,10 +2,10 @@
 
 <div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
   <div class="mb-6">
-    <%= link_to "&larr; Back to Meal Plan".html_safe, meal_plan_path(@meal_plan), class: "text-emerald-600 hover:text-emerald-700 text-sm font-medium" %>
+    <%= link_to "&larr; Back to Meal Plan".html_safe, meal_plan_path(@meal_plan), class: "text-primary-600 hover:text-primary-700 text-sm font-medium" %>
   </div>
 
-  <h1 class="text-3xl font-bold text-gray-900 mb-6">Edit Meal Plan</h1>
+  <h1 class="text-3xl font-display font-bold text-warm-900 mb-6">Edit Meal Plan</h1>
 
   <%= render "form", meal_plan: @meal_plan %>
 </div>

--- a/app/views/accounts/meal_plans/index.html.erb
+++ b/app/views/accounts/meal_plans/index.html.erb
@@ -3,15 +3,15 @@
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
   <div class="flex justify-between items-center mb-8">
     <div>
-      <h1 class="text-3xl font-bold text-gray-900">Meal Plans</h1>
-      <p class="text-gray-600 mt-1">Organize your weekly meals</p>
+      <h1 class="text-3xl font-display font-bold text-warm-900">Meal Plans</h1>
+      <p class="text-warm-600 mt-1">Organize your weekly meals</p>
     </div>
-    <%= link_to "New Meal Plan", new_meal_plan_path, class: "bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700 transition-colors text-sm font-medium" %>
+    <%= link_to "New Meal Plan", new_meal_plan_path, class: "bg-primary-600 text-white px-4 py-2 rounded-lg hover:bg-primary-700 transition-colors text-sm font-medium" %>
   </div>
 
   <% if @current_plans.any? %>
     <div class="mb-8">
-      <h2 class="text-lg font-semibold text-gray-900 mb-4">Current</h2>
+      <h2 class="text-lg font-semibold text-warm-900 mb-4">Current</h2>
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         <% @current_plans.each do |plan| %>
           <%= render "meal_plan_card", plan: plan, highlight: true %>
@@ -22,7 +22,7 @@
 
   <% if @upcoming_plans.any? %>
     <div class="mb-8">
-      <h2 class="text-lg font-semibold text-gray-900 mb-4">Upcoming</h2>
+      <h2 class="text-lg font-semibold text-warm-900 mb-4">Upcoming</h2>
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         <% @upcoming_plans.each do |plan| %>
           <%= render "meal_plan_card", plan: plan, highlight: false %>
@@ -33,7 +33,7 @@
 
   <% if @past_plans.any? %>
     <div class="mb-8">
-      <h2 class="text-lg font-semibold text-gray-900 mb-4">Past</h2>
+      <h2 class="text-lg font-semibold text-warm-900 mb-4">Past</h2>
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         <% @past_plans.each do |plan| %>
           <%= render "meal_plan_card", plan: plan, highlight: false %>
@@ -44,13 +44,13 @@
 
   <% if @current_plans.empty? && @upcoming_plans.empty? && @past_plans.empty? %>
     <div class="bg-white rounded-lg shadow px-6 py-12 text-center">
-      <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <svg class="mx-auto h-12 w-12 text-warm-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
       </svg>
-      <h3 class="mt-2 text-sm font-medium text-gray-900">No meal plans yet</h3>
-      <p class="mt-1 text-sm text-gray-500">Get started by creating your first meal plan.</p>
+      <h3 class="mt-2 text-sm font-medium text-warm-900">No meal plans yet</h3>
+      <p class="mt-1 text-sm text-warm-500">Get started by creating your first meal plan.</p>
       <div class="mt-6">
-        <%= link_to "Create Meal Plan", new_meal_plan_path, class: "bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700 transition-colors" %>
+        <%= link_to "Create Meal Plan", new_meal_plan_path, class: "bg-primary-600 text-white px-4 py-2 rounded-lg hover:bg-primary-700 transition-colors" %>
       </div>
     </div>
   <% end %>

--- a/app/views/accounts/meal_plans/new.html.erb
+++ b/app/views/accounts/meal_plans/new.html.erb
@@ -2,10 +2,10 @@
 
 <div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
   <div class="mb-6">
-    <%= link_to "&larr; Back to Meal Plans".html_safe, meal_plans_path, class: "text-emerald-600 hover:text-emerald-700 text-sm font-medium" %>
+    <%= link_to "&larr; Back to Meal Plans".html_safe, meal_plans_path, class: "text-primary-600 hover:text-primary-700 text-sm font-medium" %>
   </div>
 
-  <h1 class="text-3xl font-bold text-gray-900 mb-6">New Meal Plan</h1>
+  <h1 class="text-3xl font-display font-bold text-warm-900 mb-6">New Meal Plan</h1>
 
   <%= render "form", meal_plan: @meal_plan %>
 </div>

--- a/app/views/accounts/meal_plans/show.html.erb
+++ b/app/views/accounts/meal_plans/show.html.erb
@@ -2,34 +2,34 @@
 
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
   <div class="mb-6">
-    <%= link_to "&larr; Back to Meal Plans".html_safe, meal_plans_path, class: "text-emerald-600 hover:text-emerald-700 text-sm font-medium" %>
+    <%= link_to "&larr; Back to Meal Plans".html_safe, meal_plans_path, class: "text-primary-600 hover:text-primary-700 text-sm font-medium" %>
   </div>
 
   <div class="bg-white rounded-lg shadow mb-6">
-    <div class="p-6 border-b border-gray-200">
+    <div class="p-6 border-b border-warm-200">
       <div class="flex justify-between items-start">
         <div>
-          <h1 class="text-3xl font-bold text-gray-900"><%= @meal_plan.name || "Untitled Plan" %></h1>
-          <p class="text-gray-500 mt-1">
+          <h1 class="text-3xl font-display font-bold text-warm-900"><%= @meal_plan.name || "Untitled Plan" %></h1>
+          <p class="text-warm-500 mt-1">
             <%= @meal_plan.start_date.strftime("%B %-d") %> - <%= @meal_plan.end_date.strftime("%B %-d, %Y") %>
             (<%= @meal_plan.duration_days %> days)
           </p>
         </div>
         <div class="flex gap-2 flex-wrap">
           <% if @shopping_list %>
-            <%= link_to "Shopping List", meal_plan_shopping_list_path(@meal_plan), class: "bg-blue-50 text-blue-600 px-3 py-1.5 rounded-lg hover:bg-blue-100 text-sm font-medium" %>
+            <%= link_to "Shopping List", meal_plan_shopping_list_path(@meal_plan), class: "bg-accent-50 text-accent-600 px-3 py-1.5 rounded-lg hover:bg-accent-100 text-sm font-medium" %>
           <% else %>
-            <%= button_to "Generate Shopping List", meal_plan_shopping_list_path(@meal_plan), method: :post, class: "bg-blue-50 text-blue-600 px-3 py-1.5 rounded-lg hover:bg-blue-100 text-sm font-medium" %>
+            <%= button_to "Generate Shopping List", meal_plan_shopping_list_path(@meal_plan), method: :post, class: "bg-accent-50 text-accent-600 px-3 py-1.5 rounded-lg hover:bg-accent-100 text-sm font-medium" %>
           <% end %>
-          <button type="button" data-action="modal#open" data-modal-target="container" class="bg-gray-100 text-gray-700 px-3 py-1.5 rounded-lg hover:bg-gray-200 text-sm font-medium">Duplicate</button>
-          <%= link_to "Edit", edit_meal_plan_path(@meal_plan), class: "bg-gray-100 text-gray-700 px-3 py-1.5 rounded-lg hover:bg-gray-200 text-sm font-medium" %>
+          <button type="button" data-action="modal#open" data-modal-target="container" class="bg-warm-100 text-warm-700 px-3 py-1.5 rounded-lg hover:bg-warm-200 text-sm font-medium">Duplicate</button>
+          <%= link_to "Edit", edit_meal_plan_path(@meal_plan), class: "bg-warm-100 text-warm-700 px-3 py-1.5 rounded-lg hover:bg-warm-200 text-sm font-medium" %>
           <%= button_to "Delete", meal_plan_path(@meal_plan), method: :delete, class: "bg-red-50 text-red-600 px-3 py-1.5 rounded-lg hover:bg-red-100 text-sm font-medium", data: { turbo_confirm: "Are you sure you want to delete this meal plan?" } %>
         </div>
       </div>
     </div>
 
     <% if @meal_plan.daily_calories_target %>
-      <div class="px-6 py-3 bg-gray-50 border-b border-gray-200 text-sm text-gray-600">
+      <div class="px-6 py-3 bg-warm-50 border-b border-warm-200 text-sm text-warm-600">
         Daily calorie target: <strong><%= @meal_plan.daily_calories_target %> cal</strong>
       </div>
     <% end %>
@@ -38,29 +38,29 @@
   <% if @participants.any? %>
     <div class="bg-white rounded-lg shadow mb-6 p-4">
       <div class="flex items-center justify-between mb-3">
-        <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wider">Participants</h3>
-        <button type="button" data-action="modal#open" data-modal-target="participantsContainer" class="text-emerald-600 hover:text-emerald-700 text-sm font-medium">Edit</button>
+        <h3 class="text-sm font-semibold text-warm-700 uppercase tracking-wider">Participants</h3>
+        <button type="button" data-action="modal#open" data-modal-target="participantsContainer" class="text-primary-600 hover:text-primary-700 text-sm font-medium">Edit</button>
       </div>
       <div class="flex flex-wrap gap-4">
         <% @participants.each_with_index do |participant, index| %>
           <div class="flex items-center gap-2">
             <span class="inline-block w-3 h-3 rounded-full" style="background-color: <%= participant_color(index) %>"></span>
-            <span class="text-sm font-medium text-gray-900"><%= participant.name %></span>
+            <span class="text-sm font-medium text-warm-900"><%= participant.name %></span>
             <% if participant.diet_name.present? %>
-              <span class="text-xs text-gray-500"><%= participant.diet_name %></span>
+              <span class="text-xs text-warm-500"><%= participant.diet_name %></span>
             <% end %>
             <% if participant.daily_calories_target %>
-              <span class="text-xs text-gray-400"><%= participant.daily_calories_target %> cal</span>
+              <span class="text-xs text-warm-400"><%= participant.daily_calories_target %> cal</span>
             <% end %>
           </div>
         <% end %>
       </div>
     </div>
   <% elsif @available_profiles.any? %>
-    <div class="bg-blue-50 rounded-lg mb-6 p-4">
+    <div class="bg-accent-50 rounded-lg mb-6 p-4">
       <div class="flex items-center justify-between">
-        <p class="text-sm text-blue-700">Add family members to track individual portions and macros.</p>
-        <button type="button" data-action="modal#open" data-modal-target="participantsContainer" class="bg-blue-100 text-blue-700 px-3 py-1 rounded-lg hover:bg-blue-200 text-sm font-medium">Add Participants</button>
+        <p class="text-sm text-accent-700">Add family members to track individual portions and macros.</p>
+        <button type="button" data-action="modal#open" data-modal-target="participantsContainer" class="bg-accent-100 text-accent-700 px-3 py-1 rounded-lg hover:bg-accent-200 text-sm font-medium">Add Participants</button>
       </div>
     </div>
   <% end %>
@@ -73,7 +73,7 @@
     </div>
   <% else %>
     <div class="bg-white rounded-lg shadow px-6 py-12 text-center">
-      <p class="text-gray-500">No days in this plan yet.</p>
+      <p class="text-warm-500">No days in this plan yet.</p>
     </div>
   <% end %>
 
@@ -81,20 +81,20 @@
 
   <% if @available_profiles.any? %>
     <div data-controller="modal">
-      <div data-modal-target="participantsContainer" class="hidden fixed inset-0 bg-gray-500 bg-opacity-75 z-50 flex items-center justify-center">
+      <div data-modal-target="participantsContainer" class="hidden fixed inset-0 bg-warm-500 bg-opacity-75 z-50 flex items-center justify-center">
         <div class="bg-white rounded-lg shadow-xl max-w-md w-full mx-4 p-6">
-          <h3 class="text-lg font-semibold text-gray-900 mb-4">Edit Participants</h3>
+          <h3 class="text-lg font-semibold text-warm-900 mb-4">Edit Participants</h3>
           <%= form_with url: meal_plan_participants_path(@meal_plan), method: :post do %>
             <div class="space-y-2 mb-6">
               <% @available_profiles.each do |profile| %>
-                <label class="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-50 cursor-pointer">
+                <label class="flex items-center gap-3 p-2 rounded-lg hover:bg-warm-50 cursor-pointer">
                   <input type="checkbox" name="dietary_profile_ids[]" value="<%= profile.id %>"
                     <%= "checked" if @meal_plan.dietary_profiles.include?(profile) %>
-                    class="rounded text-emerald-600 focus:ring-emerald-500">
+                    class="rounded text-primary-600 focus:ring-primary-500">
                   <div>
-                    <span class="text-sm font-medium text-gray-900"><%= profile.name %></span>
+                    <span class="text-sm font-medium text-warm-900"><%= profile.name %></span>
                     <% if profile.diet_name.present? || profile.daily_calories_target %>
-                      <span class="text-xs text-gray-500 ml-1">
+                      <span class="text-xs text-warm-500 ml-1">
                         (<%= [profile.diet_name, profile.daily_calories_target ? "#{profile.daily_calories_target} cal" : nil].compact.join(" · ") %>)
                       </span>
                     <% end %>
@@ -103,8 +103,8 @@
               <% end %>
             </div>
             <div class="flex justify-end gap-3">
-              <button type="button" data-action="modal#close" class="px-4 py-2 text-gray-700 hover:text-gray-900 text-sm font-medium">Cancel</button>
-              <button type="submit" class="bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700 transition-colors text-sm font-medium">Update Participants</button>
+              <button type="button" data-action="modal#close" class="px-4 py-2 text-warm-700 hover:text-warm-900 text-sm font-medium">Cancel</button>
+              <button type="submit" class="bg-primary-600 text-white px-4 py-2 rounded-lg hover:bg-primary-700 transition-colors text-sm font-medium">Update Participants</button>
             </div>
           <% end %>
         </div>

--- a/app/views/accounts/recipes/_form.html.erb
+++ b/app/views/accounts/recipes/_form.html.erb
@@ -11,58 +11,58 @@
   <% end %>
 
   <div class="bg-white rounded-lg shadow p-6">
-    <h2 class="text-lg font-semibold text-gray-900 mb-4">Basic Info</h2>
+    <h2 class="text-lg font-semibold text-warm-900 mb-4">Basic Info</h2>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
       <div class="md:col-span-2">
-        <%= f.label :title, class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.text_field :title, class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500", placeholder: "Recipe title" %>
+        <%= f.label :title, class: "block text-sm font-medium text-warm-700 mb-1" %>
+        <%= f.text_field :title, class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500", placeholder: "Recipe title" %>
       </div>
       <div class="md:col-span-2">
-        <%= f.label :description, class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.text_area :description, rows: 3, class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500", placeholder: "Brief description" %>
+        <%= f.label :description, class: "block text-sm font-medium text-warm-700 mb-1" %>
+        <%= f.text_area :description, rows: 3, class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500", placeholder: "Brief description" %>
       </div>
       <div>
-        <%= f.label :category, class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.select :category, Recipe.categories.keys.map { |c| [c.titleize, c] }, { include_blank: "Select category" }, class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" %>
+        <%= f.label :category, class: "block text-sm font-medium text-warm-700 mb-1" %>
+        <%= f.select :category, Recipe.categories.keys.map { |c| [c.titleize, c] }, { include_blank: "Select category" }, class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500" %>
       </div>
       <div>
-        <%= f.label :source, class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.text_field :source, class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500", placeholder: "Source (optional)" %>
+        <%= f.label :source, class: "block text-sm font-medium text-warm-700 mb-1" %>
+        <%= f.text_field :source, class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500", placeholder: "Source (optional)" %>
       </div>
       <div>
-        <%= f.label :servings, class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.number_field :servings, min: 1, class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" %>
+        <%= f.label :servings, class: "block text-sm font-medium text-warm-700 mb-1" %>
+        <%= f.number_field :servings, min: 1, class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500" %>
       </div>
       <div>
-        <%= f.label :prep_time, "Prep time (minutes)", class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.number_field :prep_time, min: 0, class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" %>
+        <%= f.label :prep_time, "Prep time (minutes)", class: "block text-sm font-medium text-warm-700 mb-1" %>
+        <%= f.number_field :prep_time, min: 0, class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500" %>
       </div>
       <div>
-        <%= f.label :cook_time, "Cook time (minutes)", class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.number_field :cook_time, min: 0, class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" %>
+        <%= f.label :cook_time, "Cook time (minutes)", class: "block text-sm font-medium text-warm-700 mb-1" %>
+        <%= f.number_field :cook_time, min: 0, class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500" %>
       </div>
     </div>
   </div>
 
   <div class="bg-white rounded-lg shadow p-6">
-    <h2 class="text-lg font-semibold text-gray-900 mb-4">Tags</h2>
+    <h2 class="text-lg font-semibold text-warm-900 mb-4">Tags</h2>
     <div>
-      <%= f.label :tag_list, "Tags", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.text_field :tag_list, value: @recipe.tag_list, class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500", placeholder: "e.g. quick, salad, tex-mex" %>
-      <p class="mt-1 text-sm text-gray-500">Separate tags with commas</p>
+      <%= f.label :tag_list, "Tags", class: "block text-sm font-medium text-warm-700 mb-1" %>
+      <%= f.text_field :tag_list, value: @recipe.tag_list, class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500", placeholder: "e.g. quick, salad, tex-mex" %>
+      <p class="mt-1 text-sm text-warm-500">Separate tags with commas</p>
     </div>
   </div>
 
   <%# ── Ingredients ── %>
   <div class="bg-white rounded-lg shadow p-6" data-controller="nested-form">
-    <h2 class="text-lg font-semibold text-gray-900 mb-4">Ingredients</h2>
+    <h2 class="text-lg font-semibold text-warm-900 mb-4">Ingredients</h2>
 
     <div data-nested-form-target="target">
       <%= f.fields_for :ingredients do |ingredient_form| %>
         <div class="nested-form-wrapper flex gap-3 mb-3 items-center">
-          <%= ingredient_form.text_field :quantity, placeholder: "Qty", class: "w-20 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-sm" %>
-          <%= ingredient_form.select :unit, grouped_options_for_select(@unit_options, ingredient_form.object.unit), { include_blank: "Unit" }, class: "w-28 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-sm" %>
-          <%= ingredient_form.text_field :name, placeholder: "Ingredient name", class: "flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-sm" %>
+          <%= ingredient_form.text_field :quantity, placeholder: "Qty", class: "w-20 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
+          <%= ingredient_form.select :unit, grouped_options_for_select(@unit_options, ingredient_form.object.unit), { include_blank: "Unit" }, class: "w-28 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
+          <%= ingredient_form.text_field :name, placeholder: "Ingredient name", class: "flex-1 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
           <%= ingredient_form.hidden_field :_destroy, value: "0" %>
           <%= ingredient_form.hidden_field :id %>
           <button type="button" data-action="nested-form#remove" class="text-red-500 hover:text-red-700 text-sm font-medium">Remove</button>
@@ -72,29 +72,29 @@
 
     <template data-nested-form-target="template">
       <div class="nested-form-wrapper flex gap-3 mb-3 items-center" data-new-record="true">
-        <input type="text" name="recipe[ingredients_attributes][NEW_RECORD][quantity]" placeholder="Qty" class="w-20 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-sm" />
-        <select name="recipe[ingredients_attributes][NEW_RECORD][unit]" class="w-28 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-sm">
+        <input type="text" name="recipe[ingredients_attributes][NEW_RECORD][quantity]" placeholder="Qty" class="w-20 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" />
+        <select name="recipe[ingredients_attributes][NEW_RECORD][unit]" class="w-28 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm">
           <option value="">Unit</option>
           <%= grouped_options_for_select(@unit_options) %>
         </select>
-        <input type="text" name="recipe[ingredients_attributes][NEW_RECORD][name]" placeholder="Ingredient name" class="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-sm" />
+        <input type="text" name="recipe[ingredients_attributes][NEW_RECORD][name]" placeholder="Ingredient name" class="flex-1 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" />
         <input type="hidden" name="recipe[ingredients_attributes][NEW_RECORD][_destroy]" value="0" />
         <button type="button" data-action="nested-form#remove" class="text-red-500 hover:text-red-700 text-sm font-medium">Remove</button>
       </div>
     </template>
 
-    <button type="button" data-action="nested-form#add" class="mt-2 text-emerald-600 hover:text-emerald-800 text-sm font-medium">+ Add Ingredient</button>
+    <button type="button" data-action="nested-form#add" class="mt-2 text-primary-600 hover:text-primary-800 text-sm font-medium">+ Add Ingredient</button>
   </div>
 
   <%# ── Instructions ── %>
   <div class="bg-white rounded-lg shadow p-6" data-controller="nested-form step-numbering">
-    <h2 class="text-lg font-semibold text-gray-900 mb-4">Instructions</h2>
+    <h2 class="text-lg font-semibold text-warm-900 mb-4">Instructions</h2>
 
     <div data-nested-form-target="target">
       <%= f.fields_for :instructions do |instruction_form| %>
         <div class="nested-form-wrapper flex gap-3 mb-3 items-start">
-          <%= instruction_form.number_field :step_number, placeholder: "#", min: 1, readonly: true, class: "w-16 px-3 py-2 border border-gray-300 rounded-lg bg-gray-50 text-sm" %>
-          <%= instruction_form.text_area :instruction, placeholder: "Describe this step...", rows: 2, class: "flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-sm" %>
+          <%= instruction_form.number_field :step_number, placeholder: "#", min: 1, readonly: true, class: "w-16 px-3 py-2 border border-warm-300 rounded-lg bg-warm-50 text-sm" %>
+          <%= instruction_form.text_area :instruction, placeholder: "Describe this step...", rows: 2, class: "flex-1 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
           <%= instruction_form.hidden_field :_destroy, value: "0" %>
           <%= instruction_form.hidden_field :id %>
           <button type="button" data-action="nested-form#remove step-numbering#renumber" class="text-red-500 hover:text-red-700 text-sm font-medium mt-2">Remove</button>
@@ -104,24 +104,24 @@
 
     <template data-nested-form-target="template">
       <div class="nested-form-wrapper flex gap-3 mb-3 items-start" data-new-record="true">
-        <input type="number" name="recipe[instructions_attributes][NEW_RECORD][step_number]" placeholder="#" min="1" readonly class="w-16 px-3 py-2 border border-gray-300 rounded-lg bg-gray-50 text-sm" />
-        <textarea name="recipe[instructions_attributes][NEW_RECORD][instruction]" placeholder="Describe this step..." rows="2" class="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-sm"></textarea>
+        <input type="number" name="recipe[instructions_attributes][NEW_RECORD][step_number]" placeholder="#" min="1" readonly class="w-16 px-3 py-2 border border-warm-300 rounded-lg bg-warm-50 text-sm" />
+        <textarea name="recipe[instructions_attributes][NEW_RECORD][instruction]" placeholder="Describe this step..." rows="2" class="flex-1 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm"></textarea>
         <input type="hidden" name="recipe[instructions_attributes][NEW_RECORD][_destroy]" value="0" />
         <button type="button" data-action="nested-form#remove step-numbering#renumber" class="text-red-500 hover:text-red-700 text-sm font-medium mt-2">Remove</button>
       </div>
     </template>
 
-    <button type="button" data-action="nested-form#add step-numbering#renumber" class="mt-2 text-emerald-600 hover:text-emerald-800 text-sm font-medium">+ Add Step</button>
+    <button type="button" data-action="nested-form#add step-numbering#renumber" class="mt-2 text-primary-600 hover:text-primary-800 text-sm font-medium">+ Add Step</button>
   </div>
 
   <%# ── Tips ── %>
   <div class="bg-white rounded-lg shadow p-6" data-controller="nested-form">
-    <h2 class="text-lg font-semibold text-gray-900 mb-4">Tips</h2>
+    <h2 class="text-lg font-semibold text-warm-900 mb-4">Tips</h2>
 
     <div data-nested-form-target="target">
       <%= f.fields_for :tips do |tip_form| %>
         <div class="nested-form-wrapper flex gap-3 mb-3 items-start">
-          <%= tip_form.text_area :tip, placeholder: "Add a helpful tip...", rows: 2, class: "flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-sm" %>
+          <%= tip_form.text_area :tip, placeholder: "Add a helpful tip...", rows: 2, class: "flex-1 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
           <%= tip_form.hidden_field :_destroy, value: "0" %>
           <%= tip_form.hidden_field :id %>
           <button type="button" data-action="nested-form#remove" class="text-red-500 hover:text-red-700 text-sm font-medium mt-2">Remove</button>
@@ -131,30 +131,30 @@
 
     <template data-nested-form-target="template">
       <div class="nested-form-wrapper flex gap-3 mb-3 items-start" data-new-record="true">
-        <textarea name="recipe[tips_attributes][NEW_RECORD][tip]" placeholder="Add a helpful tip..." rows="2" class="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-sm"></textarea>
+        <textarea name="recipe[tips_attributes][NEW_RECORD][tip]" placeholder="Add a helpful tip..." rows="2" class="flex-1 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm"></textarea>
         <input type="hidden" name="recipe[tips_attributes][NEW_RECORD][_destroy]" value="0" />
         <button type="button" data-action="nested-form#remove" class="text-red-500 hover:text-red-700 text-sm font-medium mt-2">Remove</button>
       </div>
     </template>
 
-    <button type="button" data-action="nested-form#add" class="mt-2 text-emerald-600 hover:text-emerald-800 text-sm font-medium">+ Add Tip</button>
+    <button type="button" data-action="nested-form#add" class="mt-2 text-primary-600 hover:text-primary-800 text-sm font-medium">+ Add Tip</button>
   </div>
 
   <div class="bg-white rounded-lg shadow p-6" data-controller="nutrition-toggle">
-    <h2 class="text-lg font-semibold text-gray-900 mb-4">Nutrition (per serving)</h2>
+    <h2 class="text-lg font-semibold text-warm-900 mb-4">Nutrition (per serving)</h2>
 
     <div class="mb-4">
-      <%= f.label :nutrition_mode, "Nutrition mode", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.label :nutrition_mode, "Nutrition mode", class: "block text-sm font-medium text-warm-700 mb-1" %>
       <% default_mode = @recipe.nutrition_data&.auto_calculated? ? "auto" : (@recipe.persisted? ? "manual" : "auto") %>
-      <%= f.select :nutrition_mode, [["Auto-calculate from ingredients", "auto"], ["Enter manually", "manual"]], { selected: default_mode }, class: "w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-sm", data: { nutrition_toggle_target: "mode", action: "nutrition-toggle#toggle" } %>
+      <%= f.select :nutrition_mode, [["Auto-calculate from ingredients", "auto"], ["Enter manually", "manual"]], { selected: default_mode }, class: "w-full px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm", data: { nutrition_toggle_target: "mode", action: "nutrition-toggle#toggle" } %>
     </div>
 
     <div data-nutrition-toggle-target="autoMessage" class="hidden">
-      <p class="text-sm text-gray-600">Nutrition will be calculated automatically from ingredients when you save.</p>
+      <p class="text-sm text-warm-600">Nutrition will be calculated automatically from ingredients when you save.</p>
       <% if @recipe.nutrition_data&.auto_calculated? && @recipe.nutrition_data&.calories.present? %>
-        <div class="mt-3 bg-emerald-50 border border-emerald-200 rounded-lg p-3">
-          <p class="text-sm font-medium text-emerald-800 mb-2">Current calculated values:</p>
-          <div class="grid grid-cols-3 gap-2 text-sm text-emerald-700">
+        <div class="mt-3 bg-primary-50 border border-primary-200 rounded-lg p-3">
+          <p class="text-sm font-medium text-primary-800 mb-2">Current calculated values:</p>
+          <div class="grid grid-cols-3 gap-2 text-sm text-primary-700">
             <span>Calories: <%= @recipe.nutrition_data.calories %></span>
             <span>Fat: <%= @recipe.nutrition_data.fat %>g</span>
             <span>Protein: <%= @recipe.nutrition_data.protein %>g</span>
@@ -170,28 +170,28 @@
       <%= f.fields_for :nutrition_data do |nutrition_form| %>
         <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
           <div>
-            <%= nutrition_form.label :calories, class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= nutrition_form.number_field :calories, min: 0, class: "w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-sm" %>
+            <%= nutrition_form.label :calories, class: "block text-sm font-medium text-warm-700 mb-1" %>
+            <%= nutrition_form.number_field :calories, min: 0, class: "w-full px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
           </div>
           <div>
-            <%= nutrition_form.label :fat, "Fat (g)", class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= nutrition_form.number_field :fat, min: 0, step: 0.1, class: "w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-sm" %>
+            <%= nutrition_form.label :fat, "Fat (g)", class: "block text-sm font-medium text-warm-700 mb-1" %>
+            <%= nutrition_form.number_field :fat, min: 0, step: 0.1, class: "w-full px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
           </div>
           <div>
-            <%= nutrition_form.label :protein, "Protein (g)", class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= nutrition_form.number_field :protein, min: 0, step: 0.1, class: "w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-sm" %>
+            <%= nutrition_form.label :protein, "Protein (g)", class: "block text-sm font-medium text-warm-700 mb-1" %>
+            <%= nutrition_form.number_field :protein, min: 0, step: 0.1, class: "w-full px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
           </div>
           <div>
-            <%= nutrition_form.label :carbs, "Carbs (g)", class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= nutrition_form.number_field :carbs, min: 0, step: 0.1, class: "w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-sm" %>
+            <%= nutrition_form.label :carbs, "Carbs (g)", class: "block text-sm font-medium text-warm-700 mb-1" %>
+            <%= nutrition_form.number_field :carbs, min: 0, step: 0.1, class: "w-full px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
           </div>
           <div>
-            <%= nutrition_form.label :fiber, "Fiber (g)", class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= nutrition_form.number_field :fiber, min: 0, step: 0.1, class: "w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-sm" %>
+            <%= nutrition_form.label :fiber, "Fiber (g)", class: "block text-sm font-medium text-warm-700 mb-1" %>
+            <%= nutrition_form.number_field :fiber, min: 0, step: 0.1, class: "w-full px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
           </div>
           <div>
-            <%= nutrition_form.label :sodium, "Sodium (mg)", class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= nutrition_form.number_field :sodium, min: 0, class: "w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-sm" %>
+            <%= nutrition_form.label :sodium, "Sodium (mg)", class: "block text-sm font-medium text-warm-700 mb-1" %>
+            <%= nutrition_form.number_field :sodium, min: 0, class: "w-full px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
           </div>
         </div>
         <%= nutrition_form.hidden_field :id %>
@@ -200,7 +200,7 @@
   </div>
 
   <div class="flex gap-4">
-    <%= f.submit class: "bg-emerald-600 text-white py-2 px-6 rounded-lg hover:bg-emerald-700 focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 font-medium transition-colors cursor-pointer" %>
-    <%= link_to "Cancel", (@recipe.persisted? ? recipe_path(@recipe) : recipes_path), class: "py-2 px-4 text-gray-700 hover:text-gray-900" %>
+    <%= f.submit class: "bg-primary-600 text-white py-2 px-6 rounded-lg hover:bg-primary-700 focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 font-medium transition-colors cursor-pointer" %>
+    <%= link_to "Cancel", (@recipe.persisted? ? recipe_path(@recipe) : recipes_path), class: "py-2 px-4 text-warm-700 hover:text-warm-900" %>
   </div>
 <% end %>

--- a/app/views/accounts/recipes/_usda_search_results.html.erb
+++ b/app/views/accounts/recipes/_usda_search_results.html.erb
@@ -1,7 +1,7 @@
 <% if local_assigns[:error] && error.present? %>
   <p class="text-sm text-red-600"><%= error %></p>
 <% elsif results.empty? %>
-  <p class="text-sm text-gray-500">No results found. Try a different search term.</p>
+  <p class="text-sm text-warm-500">No results found. Try a different search term.</p>
 <% else %>
   <div class="space-y-2 max-h-64 overflow-y-auto">
     <% results.first(10).each do |food| %>
@@ -14,7 +14,7 @@
         <% when 1005 then nutrients[:carbs] = fn["value"] || fn["amount"] %>
         <% end %>
       <% end %>
-      <label data-result-card class="block border border-gray-200 rounded-lg p-3 cursor-pointer hover:bg-gray-50 transition-colors">
+      <label data-result-card class="block border border-warm-200 rounded-lg p-3 cursor-pointer hover:bg-warm-50 transition-colors">
         <div class="flex items-start gap-3">
           <input type="radio"
                  name="usda_result"
@@ -22,8 +22,8 @@
                  data-fdc-id="<%= food["fdcId"] %>"
                  data-action="usda-search#select" />
           <div>
-            <p class="font-medium text-sm text-gray-900"><%= food["description"] %></p>
-            <p class="text-xs text-gray-500 mt-1">
+            <p class="font-medium text-sm text-warm-900"><%= food["description"] %></p>
+            <p class="text-xs text-warm-500 mt-1">
               Per 100g:
               Cal <%= nutrients[:calories]&.round %>
               | Fat <%= nutrients[:fat]&.round(1) %>g

--- a/app/views/accounts/recipes/edit.html.erb
+++ b/app/views/accounts/recipes/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, "Edit #{@recipe.title} - MealSzn") %>
 
 <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-  <h1 class="text-3xl font-bold text-gray-900 mb-6">Edit Recipe</h1>
+  <h1 class="text-3xl font-display font-bold text-warm-900 mb-6">Edit Recipe</h1>
   <%= render "form", form_url: recipe_path(@recipe) %>
 </div>

--- a/app/views/accounts/recipes/index.html.erb
+++ b/app/views/accounts/recipes/index.html.erb
@@ -2,14 +2,14 @@
 
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
   <div class="flex justify-between items-center mb-6">
-    <h1 class="text-3xl font-bold text-gray-900">Recipes</h1>
-    <%= link_to "New Recipe", new_recipe_path, class: "bg-emerald-600 text-white py-2 px-4 rounded-lg hover:bg-emerald-700 font-medium transition-colors" %>
+    <h1 class="text-3xl font-display font-bold text-warm-900">Recipes</h1>
+    <%= link_to "New Recipe", new_recipe_path, class: "bg-primary-600 text-white py-2 px-4 rounded-lg hover:bg-primary-700 font-medium transition-colors" %>
   </div>
 
   <div class="flex gap-2 mb-6 flex-wrap">
-    <%= link_to "All", recipes_path, class: "px-3 py-1 rounded-full text-sm font-medium #{params[:category].blank? ? 'bg-emerald-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+    <%= link_to "All", recipes_path, class: "px-3 py-1 rounded-full text-sm font-medium #{params[:category].blank? ? 'bg-primary-600 text-white' : 'bg-warm-100 text-warm-700 hover:bg-warm-200'}" %>
     <% @categories.each do |label, value, count| %>
-      <%= link_to "#{label} (#{count})", recipes_path(category: value), class: "px-3 py-1 rounded-full text-sm font-medium #{params[:category] == value ? 'bg-emerald-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+      <%= link_to "#{label} (#{count})", recipes_path(category: value), class: "px-3 py-1 rounded-full text-sm font-medium #{params[:category] == value ? 'bg-primary-600 text-white' : 'bg-warm-100 text-warm-700 hover:bg-warm-200'}" %>
     <% end %>
   </div>
 
@@ -19,7 +19,7 @@
         <% selected = Array(params[:tags]).include?(tag.id) %>
         <% new_tags = selected ? Array(params[:tags]) - [tag.id] : Array(params[:tags]) + [tag.id] %>
         <%= link_to recipes_path(category: params[:category], tags: new_tags.presence),
-              class: "px-3 py-1 rounded-full text-sm font-medium #{selected ? 'bg-emerald-100 text-emerald-800 ring-1 ring-emerald-600' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" do %>
+              class: "px-3 py-1 rounded-full text-sm font-medium #{selected ? 'bg-primary-100 text-primary-800 ring-1 ring-primary-600' : 'bg-warm-100 text-warm-700 hover:bg-warm-200'}" do %>
           <%= tag.name %> (<%= tag.recipe_count %>)
         <% end %>
       <% end %>
@@ -32,15 +32,15 @@
         <%= link_to recipe_path(recipe), class: "block bg-white rounded-lg shadow hover:shadow-md transition-shadow" do %>
           <div class="p-6">
             <div class="flex justify-between items-start mb-2">
-              <h2 class="text-lg font-semibold text-gray-900"><%= recipe.title %></h2>
-              <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800">
+              <h2 class="text-lg font-semibold text-warm-900"><%= recipe.title %></h2>
+              <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-warm-100 text-warm-800">
                 <%= recipe.category.titleize %>
               </span>
             </div>
             <% if recipe.description.present? %>
-              <p class="text-gray-600 text-sm mb-3 line-clamp-2"><%= recipe.description %></p>
+              <p class="text-warm-600 text-sm mb-3 line-clamp-2"><%= recipe.description %></p>
             <% end %>
-            <div class="flex items-center gap-4 text-sm text-gray-500">
+            <div class="flex items-center gap-4 text-sm text-warm-500">
               <% if recipe.total_time > 0 %>
                 <span><%= recipe.total_time %> min</span>
               <% end %>
@@ -54,7 +54,7 @@
             <% if recipe.tags.any? %>
               <div class="flex gap-1 mt-2 flex-wrap">
                 <% recipe.tags.each do |tag| %>
-                  <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-emerald-50 text-emerald-700"><%= tag.name %></span>
+                  <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-primary-50 text-primary-700"><%= tag.name %></span>
                 <% end %>
               </div>
             <% end %>
@@ -63,9 +63,9 @@
       <% end %>
     </div>
   <% else %>
-    <div class="text-center py-12 bg-gray-50 rounded-lg">
-      <p class="text-gray-500 mb-4">No recipes found</p>
-      <%= link_to "Add your first recipe", new_recipe_path, class: "text-emerald-600 hover:text-emerald-700 font-medium" %>
+    <div class="text-center py-12 bg-warm-50 rounded-lg">
+      <p class="text-warm-500 mb-4">No recipes found</p>
+      <%= link_to "Add your first recipe", new_recipe_path, class: "text-primary-600 hover:text-primary-700 font-medium" %>
     </div>
   <% end %>
 </div>

--- a/app/views/accounts/recipes/new.html.erb
+++ b/app/views/accounts/recipes/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, "New Recipe - MealSzn") %>
 
 <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-  <h1 class="text-3xl font-bold text-gray-900 mb-6">New Recipe</h1>
+  <h1 class="text-3xl font-display font-bold text-warm-900 mb-6">New Recipe</h1>
   <%= render "form", form_url: recipes_path %>
 </div>

--- a/app/views/accounts/recipes/resolve_ingredients.html.erb
+++ b/app/views/accounts/recipes/resolve_ingredients.html.erb
@@ -1,7 +1,7 @@
 <div class="max-w-4xl mx-auto py-8 px-4">
   <div class="mb-6">
-    <h1 class="text-2xl font-bold text-gray-900">Match Ingredients</h1>
-    <p class="mt-2 text-gray-600">
+    <h1 class="text-2xl font-display font-bold text-warm-900">Match Ingredients</h1>
+    <p class="mt-2 text-warm-600">
       Some ingredients in "<%= @recipe.title %>" couldn't be automatically matched to nutrition data.
       Search the USDA database to find the right match for each one.
     </p>
@@ -11,7 +11,7 @@
     <% @unresolved.each do |ingredient| %>
       <div class="bg-white rounded-lg shadow p-6" data-controller="usda-search" data-usda-search-url-value="<%= search_usda_recipes_path %>">
         <div class="flex items-center justify-between mb-4">
-          <h3 class="text-lg font-medium text-gray-900">
+          <h3 class="text-lg font-medium text-warm-900">
             <%= ingredient.display_text %>
           </h3>
         </div>
@@ -20,11 +20,11 @@
           <input type="text"
                  value="<%= ingredient.name %>"
                  data-usda-search-target="query"
-                 class="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-sm"
+                 class="flex-1 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm"
                  placeholder="Search USDA database..." />
           <button type="button"
                   data-action="usda-search#search"
-                  class="px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 text-sm font-medium">
+                  class="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 text-sm font-medium">
             Search
           </button>
         </div>
@@ -41,10 +41,10 @@
 
     <div class="flex gap-4 items-center">
       <button type="submit"
-              class="bg-emerald-600 text-white py-2 px-6 rounded-lg hover:bg-emerald-700 focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 font-medium transition-colors">
+              class="bg-primary-600 text-white py-2 px-6 rounded-lg hover:bg-primary-700 focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 font-medium transition-colors">
         Apply Matches & Calculate Nutrition
       </button>
-      <%= link_to "Skip (use manual entry)", edit_recipe_path(@recipe), class: "py-2 px-4 text-gray-700 hover:text-gray-900" %>
+      <%= link_to "Skip (use manual entry)", edit_recipe_path(@recipe), class: "py-2 px-4 text-warm-700 hover:text-warm-900" %>
     </div>
   <% end %>
 </div>

--- a/app/views/accounts/recipes/show.html.erb
+++ b/app/views/accounts/recipes/show.html.erb
@@ -3,67 +3,67 @@
 <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8"
   <% if @meal_plans&.any? %>data-controller="add-to-meal-plan" data-add-to-meal-plan-recipe-id-value="<%= @recipe.id %>" data-add-to-meal-plan-base-url-value="/<%= Current.account.external_account_id %>"<% end %>>
   <div class="mb-6">
-    <%= link_to "&larr; Back to Recipes".html_safe, recipes_path, class: "text-emerald-600 hover:text-emerald-700 text-sm font-medium" %>
+    <%= link_to "&larr; Back to Recipes".html_safe, recipes_path, class: "text-primary-600 hover:text-primary-700 text-sm font-medium" %>
   </div>
 
   <div class="bg-white rounded-lg shadow">
-    <div class="p-6 border-b border-gray-200">
+    <div class="p-6 border-b border-warm-200">
       <div class="flex justify-between items-start">
         <div>
-          <h1 class="text-3xl font-bold text-gray-900"><%= @recipe.title %></h1>
+          <h1 class="text-3xl font-display font-bold text-warm-900"><%= @recipe.title %></h1>
           <div class="flex items-center gap-3 mt-2">
-            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-emerald-100 text-emerald-800">
+            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary-100 text-primary-800">
               <%= @recipe.category.titleize %>
             </span>
             <% if @recipe.total_time > 0 %>
-              <span class="text-sm text-gray-500"><%= @recipe.total_time %> min total</span>
+              <span class="text-sm text-warm-500"><%= @recipe.total_time %> min total</span>
             <% end %>
             <% if @recipe.servings %>
-              <span class="text-sm text-gray-500"><%= @recipe.servings %> servings</span>
+              <span class="text-sm text-warm-500"><%= @recipe.servings %> servings</span>
             <% end %>
           </div>
           <% if @recipe.tags.any? %>
             <div class="flex gap-1.5 mt-2 flex-wrap">
               <% @recipe.tags.each do |tag| %>
                 <%= link_to tag.name, recipes_path(tags: [tag.id]),
-                      class: "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-emerald-50 text-emerald-700 hover:bg-emerald-100" %>
+                      class: "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary-50 text-primary-700 hover:bg-primary-100" %>
               <% end %>
             </div>
           <% end %>
         </div>
         <div class="flex gap-2">
           <% if @meal_plans&.any? %>
-            <button type="button" data-action="add-to-meal-plan#open" class="bg-blue-50 text-blue-600 px-3 py-1.5 rounded-lg hover:bg-blue-100 text-sm font-medium">Add to Meal Plan</button>
+            <button type="button" data-action="add-to-meal-plan#open" class="bg-accent-50 text-accent-600 px-3 py-1.5 rounded-lg hover:bg-accent-100 text-sm font-medium">Add to Meal Plan</button>
           <% end %>
-          <%= link_to "Edit", edit_recipe_path(@recipe), class: "bg-gray-100 text-gray-700 px-3 py-1.5 rounded-lg hover:bg-gray-200 text-sm font-medium" %>
+          <%= link_to "Edit", edit_recipe_path(@recipe), class: "bg-warm-100 text-warm-700 px-3 py-1.5 rounded-lg hover:bg-warm-200 text-sm font-medium" %>
           <%= button_to "Delete", recipe_path(@recipe), method: :delete, class: "bg-red-50 text-red-600 px-3 py-1.5 rounded-lg hover:bg-red-100 text-sm font-medium", data: { turbo_confirm: "Are you sure?" } %>
         </div>
       </div>
       <% if @recipe.description.present? %>
-        <p class="text-gray-600 mt-3"><%= @recipe.description %></p>
+        <p class="text-warm-600 mt-3"><%= @recipe.description %></p>
       <% end %>
     </div>
 
     <% if @recipe.nutrition_data %>
-      <div class="p-6 border-b border-gray-200 bg-gray-50">
-        <h2 class="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-3">Nutrition per Serving</h2>
+      <div class="p-6 border-b border-warm-200 bg-warm-50">
+        <h2 class="text-sm font-semibold text-warm-500 uppercase tracking-wider mb-3">Nutrition per Serving</h2>
         <div class="grid grid-cols-2 md:grid-cols-5 gap-4">
-          <div><span class="text-2xl font-bold text-gray-900"><%= @recipe.nutrition_data.calories %></span><br><span class="text-xs text-gray-500">Calories</span></div>
-          <div><span class="text-2xl font-bold text-gray-900"><%= @recipe.nutrition_data.fat %>g</span><br><span class="text-xs text-gray-500">Fat</span></div>
-          <div><span class="text-2xl font-bold text-gray-900"><%= @recipe.nutrition_data.protein %>g</span><br><span class="text-xs text-gray-500">Protein</span></div>
-          <div><span class="text-2xl font-bold text-gray-900"><%= @recipe.nutrition_data.net_carbs %>g</span><br><span class="text-xs text-gray-500">Net Carbs</span></div>
-          <div><span class="text-2xl font-bold text-gray-900"><%= @recipe.nutrition_data.fiber %>g</span><br><span class="text-xs text-gray-500">Fiber</span></div>
+          <div><span class="text-2xl font-display font-bold text-warm-900"><%= @recipe.nutrition_data.calories %></span><br><span class="text-xs text-warm-500">Calories</span></div>
+          <div><span class="text-2xl font-display font-bold text-warm-900"><%= @recipe.nutrition_data.fat %>g</span><br><span class="text-xs text-warm-500">Fat</span></div>
+          <div><span class="text-2xl font-display font-bold text-warm-900"><%= @recipe.nutrition_data.protein %>g</span><br><span class="text-xs text-warm-500">Protein</span></div>
+          <div><span class="text-2xl font-display font-bold text-warm-900"><%= @recipe.nutrition_data.net_carbs %>g</span><br><span class="text-xs text-warm-500">Net Carbs</span></div>
+          <div><span class="text-2xl font-display font-bold text-warm-900"><%= @recipe.nutrition_data.fiber %>g</span><br><span class="text-xs text-warm-500">Fiber</span></div>
         </div>
       </div>
     <% end %>
 
     <% if @recipe.ingredients.any? %>
-      <div class="p-6 border-b border-gray-200">
-        <h2 class="text-lg font-semibold text-gray-900 mb-3">Ingredients</h2>
+      <div class="p-6 border-b border-warm-200">
+        <h2 class="text-lg font-semibold text-warm-900 mb-3">Ingredients</h2>
         <ul class="space-y-2">
           <% @recipe.ingredients.each do |ingredient| %>
-            <li class="flex items-center text-gray-700">
-              <span class="w-2 h-2 bg-emerald-400 rounded-full mr-3 flex-shrink-0"></span>
+            <li class="flex items-center text-warm-700">
+              <span class="w-2 h-2 bg-primary-400 rounded-full mr-3 flex-shrink-0"></span>
               <%= ingredient.display_text %>
             </li>
           <% end %>
@@ -72,15 +72,15 @@
     <% end %>
 
     <% if @recipe.instructions.any? %>
-      <div class="p-6 border-b border-gray-200">
-        <h2 class="text-lg font-semibold text-gray-900 mb-3">Instructions</h2>
+      <div class="p-6 border-b border-warm-200">
+        <h2 class="text-lg font-semibold text-warm-900 mb-3">Instructions</h2>
         <ol class="space-y-4">
           <% @recipe.instructions.each do |instruction| %>
             <li class="flex">
-              <span class="flex-shrink-0 w-8 h-8 bg-emerald-100 text-emerald-700 rounded-full flex items-center justify-center font-semibold text-sm mr-3">
+              <span class="flex-shrink-0 w-8 h-8 bg-primary-100 text-primary-700 rounded-full flex items-center justify-center font-semibold text-sm mr-3">
                 <%= instruction.step_number %>
               </span>
-              <p class="text-gray-700 pt-1"><%= instruction.instruction %></p>
+              <p class="text-warm-700 pt-1"><%= instruction.instruction %></p>
             </li>
           <% end %>
         </ol>
@@ -89,10 +89,10 @@
 
     <% if @recipe.tips.any? %>
       <div class="p-6">
-        <h2 class="text-lg font-semibold text-gray-900 mb-3">Tips</h2>
+        <h2 class="text-lg font-semibold text-warm-900 mb-3">Tips</h2>
         <ul class="space-y-2">
           <% @recipe.tips.each do |tip| %>
-            <li class="flex items-start text-gray-600 text-sm">
+            <li class="flex items-start text-warm-600 text-sm">
               <svg class="w-5 h-5 text-yellow-500 mr-2 flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
                 <path d="M11 3a1 1 0 10-2 0v1a1 1 0 102 0V3zM15.657 5.757a1 1 0 00-1.414-1.414l-.707.707a1 1 0 001.414 1.414l.707-.707z"/>
               </svg>

--- a/app/views/accounts/settings/show.html.erb
+++ b/app/views/accounts/settings/show.html.erb
@@ -1,63 +1,63 @@
 <div class="w-full max-w-2xl mx-auto">
-  <h1 class="text-2xl font-bold text-gray-900 mb-6">Settings</h1>
+  <h1 class="text-2xl font-display font-bold text-warm-900 mb-6">Settings</h1>
 
   <%= form_with model: @settings, url: settings_path, method: :patch, class: "space-y-8" do |f| %>
     <div class="bg-white rounded-lg shadow p-6">
-      <h2 class="text-lg font-semibold text-gray-900 mb-4">Unit System</h2>
-      <p class="text-sm text-gray-600 mb-4">Choose which unit system appears first in recipe ingredient dropdowns.</p>
+      <h2 class="text-lg font-semibold text-warm-900 mb-4">Unit System</h2>
+      <p class="text-sm text-warm-600 mb-4">Choose which unit system appears first in recipe ingredient dropdowns.</p>
       <div class="flex gap-6">
         <label class="flex items-center gap-2 cursor-pointer">
-          <%= f.radio_button :unit_system, "standard", class: "text-emerald-600 focus:ring-emerald-500" %>
-          <span class="text-sm font-medium text-gray-700">Standard</span>
-          <span class="text-xs text-gray-500">(cups, tbsp, oz, lb)</span>
+          <%= f.radio_button :unit_system, "standard", class: "text-primary-600 focus:ring-primary-500" %>
+          <span class="text-sm font-medium text-warm-700">Standard</span>
+          <span class="text-xs text-warm-500">(cups, tbsp, oz, lb)</span>
         </label>
         <label class="flex items-center gap-2 cursor-pointer">
-          <%= f.radio_button :unit_system, "metric", class: "text-emerald-600 focus:ring-emerald-500" %>
-          <span class="text-sm font-medium text-gray-700">Metric</span>
-          <span class="text-xs text-gray-500">(ml, l, g, kg)</span>
+          <%= f.radio_button :unit_system, "metric", class: "text-primary-600 focus:ring-primary-500" %>
+          <span class="text-sm font-medium text-warm-700">Metric</span>
+          <span class="text-xs text-warm-500">(ml, l, g, kg)</span>
         </label>
       </div>
     </div>
 
     <div class="bg-white rounded-lg shadow p-6">
-      <h2 class="text-lg font-semibold text-gray-900 mb-4">Timezone</h2>
+      <h2 class="text-lg font-semibold text-warm-900 mb-4">Timezone</h2>
       <div>
-        <%= f.label :timezone, class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.time_zone_select :timezone, nil, { default: @settings.timezone }, class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" %>
+        <%= f.label :timezone, class: "block text-sm font-medium text-warm-700 mb-1" %>
+        <%= f.time_zone_select :timezone, nil, { default: @settings.timezone }, class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500" %>
       </div>
     </div>
 
     <div class="bg-white rounded-lg shadow p-6">
-      <h2 class="text-lg font-semibold text-gray-900 mb-4">Email Notifications</h2>
+      <h2 class="text-lg font-semibold text-warm-900 mb-4">Email Notifications</h2>
       <div>
-        <%= f.label :email_frequency, class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.select :email_frequency, User::Settings.email_frequencies.keys.map { |k| [k.titleize, k] }, {}, class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" %>
+        <%= f.label :email_frequency, class: "block text-sm font-medium text-warm-700 mb-1" %>
+        <%= f.select :email_frequency, User::Settings.email_frequencies.keys.map { |k| [k.titleize, k] }, {}, class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500" %>
       </div>
     </div>
 
     <div class="flex gap-4">
-      <%= f.submit "Save Settings", class: "bg-emerald-600 text-white py-2 px-6 rounded-lg hover:bg-emerald-700 focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 font-medium transition-colors cursor-pointer" %>
+      <%= f.submit "Save Settings", class: "bg-primary-600 text-white py-2 px-6 rounded-lg hover:bg-primary-700 focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 font-medium transition-colors cursor-pointer" %>
     </div>
   <% end %>
 
   <% if Current.user.admin? %>
     <%= form_with model: @account, url: settings_path, method: :patch, class: "space-y-8 mt-8" do |f| %>
       <div class="bg-white rounded-lg shadow p-6">
-        <h2 class="text-lg font-semibold text-gray-900 mb-4">Account Defaults</h2>
-        <p class="text-sm text-gray-600 mb-4">Default diet and calorie target for new dietary profiles.</p>
+        <h2 class="text-lg font-semibold text-warm-900 mb-4">Account Defaults</h2>
+        <p class="text-sm text-warm-600 mb-4">Default diet and calorie target for new dietary profiles.</p>
         <div class="space-y-4">
           <div>
-            <%= f.label :default_diet_name, "Default Diet", class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= f.select :default_diet_name, DietRegistry.diet_names.map { |n| [n, n] }, { include_blank: "No default" }, class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" %>
+            <%= f.label :default_diet_name, "Default Diet", class: "block text-sm font-medium text-warm-700 mb-1" %>
+            <%= f.select :default_diet_name, DietRegistry.diet_names.map { |n| [n, n] }, { include_blank: "No default" }, class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500" %>
           </div>
           <div>
-            <%= f.label :default_daily_calories_target, "Default Daily Calories", class: "block text-sm font-medium text-gray-700 mb-1" %>
-            <%= f.number_field :default_daily_calories_target, class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500", placeholder: "e.g., 2000", min: 1 %>
+            <%= f.label :default_daily_calories_target, "Default Daily Calories", class: "block text-sm font-medium text-warm-700 mb-1" %>
+            <%= f.number_field :default_daily_calories_target, class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500", placeholder: "e.g., 2000", min: 1 %>
           </div>
         </div>
       </div>
       <div class="flex gap-4">
-        <%= f.submit "Save Account Defaults", class: "bg-emerald-600 text-white py-2 px-6 rounded-lg hover:bg-emerald-700 focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 font-medium transition-colors cursor-pointer" %>
+        <%= f.submit "Save Account Defaults", class: "bg-primary-600 text-white py-2 px-6 rounded-lg hover:bg-primary-700 focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 font-medium transition-colors cursor-pointer" %>
       </div>
     <% end %>
   <% end %>
@@ -65,10 +65,10 @@
   <div class="bg-white rounded-lg shadow p-6 mt-8">
     <div class="flex justify-between items-center">
       <div>
-        <h2 class="text-lg font-semibold text-gray-900">Family Dietary Profiles</h2>
-        <p class="text-sm text-gray-600 mt-1">Manage dietary profiles for your family members.</p>
+        <h2 class="text-lg font-semibold text-warm-900">Family Dietary Profiles</h2>
+        <p class="text-sm text-warm-600 mt-1">Manage dietary profiles for your family members.</p>
       </div>
-      <%= link_to "Manage Profiles", dietary_profiles_path, class: "bg-emerald-600 text-white px-4 py-2 rounded-lg hover:bg-emerald-700 transition-colors text-sm font-medium" %>
+      <%= link_to "Manage Profiles", dietary_profiles_path, class: "bg-primary-600 text-white px-4 py-2 rounded-lg hover:bg-primary-700 transition-colors text-sm font-medium" %>
     </div>
   </div>
 </div>

--- a/app/views/accounts/shopping_lists/show.html.erb
+++ b/app/views/accounts/shopping_lists/show.html.erb
@@ -2,27 +2,27 @@
 
 <div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
   <div class="mb-6">
-    <%= link_to "&larr; Back to Meal Plan".html_safe, meal_plan_path(@meal_plan), class: "text-emerald-600 hover:text-emerald-700 text-sm font-medium" %>
+    <%= link_to "&larr; Back to Meal Plan".html_safe, meal_plan_path(@meal_plan), class: "text-primary-600 hover:text-primary-700 text-sm font-medium" %>
   </div>
 
   <div class="bg-white rounded-lg shadow">
-    <div class="p-6 border-b border-gray-200">
+    <div class="p-6 border-b border-warm-200">
       <div class="flex justify-between items-start">
         <div>
-          <h1 class="text-2xl font-bold text-gray-900"><%= @shopping_list.name || "Shopping List" %></h1>
-          <p class="text-sm text-gray-500 mt-1">
+          <h1 class="text-2xl font-display font-bold text-warm-900"><%= @shopping_list.name || "Shopping List" %></h1>
+          <p class="text-sm text-warm-500 mt-1">
             <%= @shopping_list.checked_count %> of <%= @shopping_list.total_count %> items checked
           </p>
         </div>
         <div class="flex gap-2">
-          <%= button_to "Regenerate", meal_plan_shopping_list_path(@meal_plan), method: :post, class: "bg-gray-100 text-gray-700 px-3 py-1.5 rounded-lg hover:bg-gray-200 text-sm font-medium", data: { turbo_confirm: "This will replace the current shopping list. Continue?" } %>
+          <%= button_to "Regenerate", meal_plan_shopping_list_path(@meal_plan), method: :post, class: "bg-warm-100 text-warm-700 px-3 py-1.5 rounded-lg hover:bg-warm-200 text-sm font-medium", data: { turbo_confirm: "This will replace the current shopping list. Continue?" } %>
           <%= button_to "Delete", meal_plan_shopping_list_path(@meal_plan), method: :delete, class: "bg-red-50 text-red-600 px-3 py-1.5 rounded-lg hover:bg-red-100 text-sm font-medium", data: { turbo_confirm: "Delete this shopping list?" } %>
         </div>
       </div>
 
       <% if @shopping_list.total_count > 0 %>
-        <div class="mt-3 w-full bg-gray-200 rounded-full h-2">
-          <div class="bg-emerald-500 h-2 rounded-full" style="width: <%= (@shopping_list.checked_count.to_f / @shopping_list.total_count * 100).round %>%"></div>
+        <div class="mt-3 w-full bg-warm-200 rounded-full h-2">
+          <div class="bg-primary-500 h-2 rounded-full" style="width: <%= (@shopping_list.checked_count.to_f / @shopping_list.total_count * 100).round %>%"></div>
         </div>
       <% end %>
     </div>
@@ -31,16 +31,16 @@
     <% checked = @shopping_list.items.checked.alphabetical %>
 
     <% if unchecked.any? %>
-      <div class="p-6 <%= checked.any? ? 'border-b border-gray-200' : '' %>">
-        <h2 class="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-3">To Buy (<%= unchecked.size %>)</h2>
+      <div class="p-6 <%= checked.any? ? 'border-b border-warm-200' : '' %>">
+        <h2 class="text-sm font-semibold text-warm-500 uppercase tracking-wider mb-3">To Buy (<%= unchecked.size %>)</h2>
         <ul class="space-y-2">
           <% unchecked.each do |item| %>
             <li class="flex items-center justify-between group">
               <div class="flex items-center gap-3">
                 <%= button_to toggle_shopping_list_item_path(item), method: :patch, class: "flex items-center" do %>
-                  <span class="w-5 h-5 border-2 border-gray-300 rounded flex items-center justify-center hover:border-emerald-500 cursor-pointer"></span>
+                  <span class="w-5 h-5 border-2 border-warm-300 rounded flex items-center justify-center hover:border-primary-500 cursor-pointer"></span>
                 <% end %>
-                <span class="text-gray-900"><%= item.display_text %></span>
+                <span class="text-warm-900"><%= item.display_text %></span>
               </div>
               <%= button_to shopping_list_item_path(item), method: :delete, class: "text-red-400 hover:text-red-600 opacity-0 group-hover:opacity-100 transition-opacity", data: { turbo_confirm: "Remove this item?" } do %>
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -55,19 +55,19 @@
 
     <% if checked.any? %>
       <div class="p-6">
-        <h2 class="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-3">Checked Off (<%= checked.size %>)</h2>
+        <h2 class="text-sm font-semibold text-warm-500 uppercase tracking-wider mb-3">Checked Off (<%= checked.size %>)</h2>
         <ul class="space-y-2">
           <% checked.each do |item| %>
             <li class="flex items-center justify-between group">
               <div class="flex items-center gap-3">
                 <%= button_to toggle_shopping_list_item_path(item), method: :patch, class: "flex items-center" do %>
-                  <span class="w-5 h-5 border-2 border-emerald-500 bg-emerald-500 rounded flex items-center justify-center cursor-pointer">
+                  <span class="w-5 h-5 border-2 border-primary-500 bg-primary-500 rounded flex items-center justify-center cursor-pointer">
                     <svg class="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7"/>
                     </svg>
                   </span>
                 <% end %>
-                <span class="text-gray-400 line-through"><%= item.display_text %></span>
+                <span class="text-warm-400 line-through"><%= item.display_text %></span>
               </div>
               <%= button_to shopping_list_item_path(item), method: :delete, class: "text-red-400 hover:text-red-600 opacity-0 group-hover:opacity-100 transition-opacity", data: { turbo_confirm: "Remove this item?" } do %>
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -81,7 +81,7 @@
     <% end %>
 
     <% if @shopping_list.items.empty? %>
-      <div class="p-6 text-center text-gray-500">
+      <div class="p-6 text-center text-warm-500">
         <p>No items in this shopping list.</p>
       </div>
     <% end %>

--- a/app/views/identity/access_tokens/index.html.erb
+++ b/app/views/identity/access_tokens/index.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:title, "API Access Tokens - MealSzn") %>
 
 <div class="flex justify-between items-center mb-6">
-  <h2 class="text-2xl font-bold text-gray-900">API Access Tokens</h2>
+  <h2 class="text-2xl font-display font-bold text-warm-900">API Access Tokens</h2>
   <%= link_to "New Token", new_identity_access_token_path,
-      class: "bg-emerald-600 text-white py-2 px-4 rounded-lg hover:bg-emerald-700 font-medium transition-colors" %>
+      class: "bg-primary-600 text-white py-2 px-4 rounded-lg hover:bg-primary-700 font-medium transition-colors" %>
 </div>
 
 <% if flash[:token] %>
@@ -15,35 +15,35 @@
 
 <% if @access_tokens.any? %>
   <div class="bg-white shadow rounded-lg overflow-hidden">
-    <table class="min-w-full divide-y divide-gray-200">
-      <thead class="bg-gray-50">
+    <table class="min-w-full divide-y divide-warm-200">
+      <thead class="bg-warm-50">
         <tr>
-          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Permission</th>
-          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Expires</th>
-          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+          <th class="px-6 py-3 text-left text-xs font-medium text-warm-500 uppercase tracking-wider">Name</th>
+          <th class="px-6 py-3 text-left text-xs font-medium text-warm-500 uppercase tracking-wider">Permission</th>
+          <th class="px-6 py-3 text-left text-xs font-medium text-warm-500 uppercase tracking-wider">Expires</th>
+          <th class="px-6 py-3 text-left text-xs font-medium text-warm-500 uppercase tracking-wider">Created</th>
           <th class="px-6 py-3"></th>
         </tr>
       </thead>
-      <tbody class="bg-white divide-y divide-gray-200">
+      <tbody class="bg-white divide-y divide-warm-200">
         <% @access_tokens.each do |token| %>
           <tr>
-            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-warm-900">
               <%= token.name || "Unnamed token" %>
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-              <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium <%= token.write? ? 'bg-orange-100 text-orange-800' : 'bg-blue-100 text-blue-800' %>">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-warm-500">
+              <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium <%= token.write? ? 'bg-orange-100 text-orange-800' : 'bg-accent-100 text-accent-800' %>">
                 <%= token.permission %>
               </span>
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-warm-500">
               <% if token.expires_at %>
                 <%= token.expires_at.strftime("%b %d, %Y") %>
               <% else %>
-                <span class="text-gray-400">Never</span>
+                <span class="text-warm-400">Never</span>
               <% end %>
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-warm-500">
               <%= token.created_at.strftime("%b %d, %Y") %>
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
@@ -58,8 +58,8 @@
     </table>
   </div>
 <% else %>
-  <div class="text-center py-12 bg-gray-50 rounded-lg">
-    <p class="text-gray-500 mb-4">No access tokens yet</p>
-    <p class="text-sm text-gray-400">Create a token to access the API from external applications</p>
+  <div class="text-center py-12 bg-warm-50 rounded-lg">
+    <p class="text-warm-500 mb-4">No access tokens yet</p>
+    <p class="text-sm text-warm-400">Create a token to access the API from external applications</p>
   </div>
 <% end %>

--- a/app/views/identity/access_tokens/new.html.erb
+++ b/app/views/identity/access_tokens/new.html.erb
@@ -1,37 +1,37 @@
 <% content_for(:title, "Create Access Token - MealSzn") %>
 
-<h2 class="text-2xl font-bold text-gray-900 mb-6">Create Access Token</h2>
+<h2 class="text-2xl font-display font-bold text-warm-900 mb-6">Create Access Token</h2>
 
 <%= form_with model: @access_token, url: identity_access_tokens_path, class: "space-y-6" do |f| %>
   <div>
-    <%= f.label :name, "Token name", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.label :name, "Token name", class: "block text-sm font-medium text-warm-700 mb-1" %>
     <%= f.text_field :name,
         autofocus: true,
-        class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500",
+        class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500",
         placeholder: "My API Token" %>
-    <p class="mt-1 text-sm text-gray-500">A friendly name to identify this token</p>
+    <p class="mt-1 text-sm text-warm-500">A friendly name to identify this token</p>
   </div>
 
   <div>
-    <%= f.label :permission, "Permission level", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.label :permission, "Permission level", class: "block text-sm font-medium text-warm-700 mb-1" %>
     <%= f.select :permission,
         [["Read only - Can read recipes and meal plans", "read"], ["Read and write - Can create and modify data", "write"]],
         {},
-        class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" %>
+        class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500" %>
   </div>
 
   <div>
-    <%= f.label :expires_at, "Expiration date (optional)", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.label :expires_at, "Expiration date (optional)", class: "block text-sm font-medium text-warm-700 mb-1" %>
     <%= f.date_field :expires_at,
         min: Date.tomorrow,
-        class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" %>
-    <p class="mt-1 text-sm text-gray-500">Leave blank for a token that never expires</p>
+        class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500" %>
+    <p class="mt-1 text-sm text-warm-500">Leave blank for a token that never expires</p>
   </div>
 
   <div class="flex gap-4">
     <%= f.submit "Create token",
-        class: "bg-emerald-600 text-white py-2 px-4 rounded-lg hover:bg-emerald-700 focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 font-medium transition-colors cursor-pointer" %>
+        class: "bg-primary-600 text-white py-2 px-4 rounded-lg hover:bg-primary-700 focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 font-medium transition-colors cursor-pointer" %>
     <%= link_to "Cancel", identity_access_tokens_path,
-        class: "py-2 px-4 text-gray-700 hover:text-gray-900" %>
+        class: "py-2 px-4 text-warm-700 hover:text-warm-900" %>
   </div>
 <% end %>

--- a/app/views/identity/sessions/index.html.erb
+++ b/app/views/identity/sessions/index.html.erb
@@ -1,24 +1,24 @@
 <% content_for(:title, "Active Sessions - MealSzn") %>
 
-<h2 class="text-2xl font-bold text-gray-900 mb-6">Active Sessions</h2>
+<h2 class="text-2xl font-display font-bold text-warm-900 mb-6">Active Sessions</h2>
 
 <div class="bg-white shadow rounded-lg overflow-hidden">
-  <table class="min-w-full divide-y divide-gray-200">
-    <thead class="bg-gray-50">
+  <table class="min-w-full divide-y divide-warm-200">
+    <thead class="bg-warm-50">
       <tr>
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Device</th>
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">IP Address</th>
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Active</th>
+        <th class="px-6 py-3 text-left text-xs font-medium text-warm-500 uppercase tracking-wider">Device</th>
+        <th class="px-6 py-3 text-left text-xs font-medium text-warm-500 uppercase tracking-wider">IP Address</th>
+        <th class="px-6 py-3 text-left text-xs font-medium text-warm-500 uppercase tracking-wider">Last Active</th>
         <th class="px-6 py-3"></th>
       </tr>
     </thead>
-    <tbody class="bg-white divide-y divide-gray-200">
+    <tbody class="bg-white divide-y divide-warm-200">
       <% @sessions.each do |session| %>
-        <tr class="<%= session == @current_session ? 'bg-emerald-50' : '' %>">
-          <td class="px-6 py-4 text-sm text-gray-900">
+        <tr class="<%= session == @current_session ? 'bg-primary-50' : '' %>">
+          <td class="px-6 py-4 text-sm text-warm-900">
             <div class="flex items-center">
               <% if session == @current_session %>
-                <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-emerald-100 text-emerald-800 mr-2">
+                <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-primary-100 text-primary-800 mr-2">
                   Current
                 </span>
               <% end %>
@@ -27,10 +27,10 @@
               </span>
             </div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+          <td class="px-6 py-4 whitespace-nowrap text-sm text-warm-500">
             <%= session.ip_address || "Unknown" %>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+          <td class="px-6 py-4 whitespace-nowrap text-sm text-warm-500">
             <%= time_ago_in_words(session.updated_at) %> ago
           </td>
           <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,12 +18,16 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
 
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Bitter:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Nunito+Sans:ital,opsz,wght@0,6..12,300;0,6..12,400;0,6..12,500;0,6..12,600;0,6..12,700;1,6..12,400&display=swap" rel="stylesheet">
+
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag "tailwind", :app, "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="bg-gray-50 min-h-screen">
+  <body class="bg-warm-gradient min-h-screen">
     <% if Current.account %>
       <%= render "shared/navbar" %>
     <% end %>

--- a/app/views/layouts/public.html.erb
+++ b/app/views/layouts/public.html.erb
@@ -7,14 +7,18 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Bitter:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Nunito+Sans:ital,opsz,wght@0,6..12,300;0,6..12,400;0,6..12,500;0,6..12,600;0,6..12,700;1,6..12,400&display=swap" rel="stylesheet">
+
     <%= stylesheet_link_tag "tailwind", "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="bg-gray-50 min-h-screen flex flex-col">
-    <header class="bg-white shadow-sm">
+  <body class="bg-warm-gradient min-h-screen flex flex-col">
+    <header class="bg-white/80 backdrop-blur-sm shadow-sm">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-        <h1 class="text-2xl font-bold text-emerald-600">MealSzn</h1>
+        <h1 class="text-2xl font-display font-bold text-primary-700">MealSzn</h1>
       </div>
     </header>
 
@@ -32,14 +36,14 @@
           </div>
         <% end %>
 
-        <div class="bg-white shadow-lg rounded-lg p-8">
+        <div class="card-warm rounded-xl p-8">
           <%= yield %>
         </div>
       </div>
     </main>
 
-    <footer class="bg-white border-t">
-      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 text-center text-gray-500 text-sm">
+    <footer class="bg-white/60 border-t border-warm-200">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 text-center text-warm-500 text-sm">
         &copy; <%= Time.current.year %> MealSzn. All rights reserved.
       </div>
     </footer>

--- a/app/views/onboardings/completions/new.html.erb
+++ b/app/views/onboardings/completions/new.html.erb
@@ -1,35 +1,35 @@
 <% content_for(:title, "Set up your organization - MealSzn") %>
 
-<h2 class="text-2xl font-bold text-gray-900 mb-2 text-center">Set up your organization</h2>
+<h2 class="text-2xl font-display font-bold text-warm-900 mb-2 text-center">Set up your organization</h2>
 
-<p class="text-gray-600 mb-6 text-center">
+<p class="text-warm-600 mb-6 text-center">
   Tell us about yourself and your organization
 </p>
 
 <%= form_with model: @onboarding, url: onboarding_completion_path, method: :post, class: "space-y-6" do |f| %>
   <div>
-    <%= f.label :full_name, "Your name", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.label :full_name, "Your name", class: "block text-sm font-medium text-warm-700 mb-1" %>
     <%= f.text_field :full_name,
         required: true,
         autofocus: true,
         autocomplete: "name",
         name: "full_name",
-        class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500",
+        class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500",
         placeholder: "Jane Smith" %>
   </div>
 
   <div>
-    <%= f.label :organization_name, "Organization name", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.label :organization_name, "Organization name", class: "block text-sm font-medium text-warm-700 mb-1" %>
     <%= f.text_field :organization_name,
         required: true,
         autocomplete: "organization",
         name: "organization_name",
-        class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500",
+        class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500",
         placeholder: "Acme Inc." %>
   </div>
 
   <div>
     <%= f.submit "Complete setup",
-        class: "w-full bg-emerald-600 text-white py-2 px-4 rounded-lg hover:bg-emerald-700 focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 font-medium transition-colors cursor-pointer" %>
+        class: "w-full bg-primary-600 text-white py-2 px-4 rounded-lg hover:bg-primary-700 focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 font-medium transition-colors cursor-pointer" %>
   </div>
 <% end %>

--- a/app/views/onboardings/new.html.erb
+++ b/app/views/onboardings/new.html.erb
@@ -1,24 +1,24 @@
 <% content_for(:title, "Get Started - MealSzn") %>
 
-<h2 class="text-2xl font-bold text-gray-900 mb-2 text-center">Welcome to MealSzn</h2>
+<h2 class="text-2xl font-display font-bold text-warm-900 mb-2 text-center">Welcome to MealSzn</h2>
 
-<p class="text-gray-600 mb-6 text-center">
+<p class="text-warm-600 mb-6 text-center">
   Let's set up your organization. Enter your email to get started.
 </p>
 
 <%= form_with url: onboarding_path, method: :post, class: "space-y-6" do |f| %>
   <div>
-    <%= f.label :email_address, "Email address", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.label :email_address, "Email address", class: "block text-sm font-medium text-warm-700 mb-1" %>
     <%= f.email_field :email_address,
         required: true,
         autofocus: true,
         autocomplete: "email",
-        class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500",
+        class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500",
         placeholder: "you@example.com" %>
   </div>
 
   <div>
     <%= f.submit "Continue",
-        class: "w-full bg-emerald-600 text-white py-2 px-4 rounded-lg hover:bg-emerald-700 focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 font-medium transition-colors cursor-pointer" %>
+        class: "w-full bg-primary-600 text-white py-2 px-4 rounded-lg hover:bg-primary-700 focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 font-medium transition-colors cursor-pointer" %>
   </div>
 <% end %>

--- a/app/views/sessions/magic_links/show.html.erb
+++ b/app/views/sessions/magic_links/show.html.erb
@@ -1,31 +1,31 @@
 <% content_for(:title, "Enter code - MealSzn") %>
 
-<h2 class="text-2xl font-bold text-gray-900 mb-2 text-center">Check your email</h2>
+<h2 class="text-2xl font-display font-bold text-warm-900 mb-2 text-center">Check your email</h2>
 
-<p class="text-gray-600 mb-6 text-center">
+<p class="text-warm-600 mb-6 text-center">
   We sent a 6-digit code to<br>
-  <strong class="text-gray-900"><%= @email_address %></strong>
+  <strong class="text-warm-900"><%= @email_address %></strong>
 </p>
 
 <%= form_with url: session_magic_link_path, method: :post, class: "space-y-6" do |f| %>
   <div>
-    <%= f.label :code, "Verification code", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.label :code, "Verification code", class: "block text-sm font-medium text-warm-700 mb-1" %>
     <%= f.text_field :code,
         required: true,
         autofocus: true,
         autocomplete: "one-time-code",
         maxlength: 7,
-        class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-center text-2xl tracking-widest font-mono uppercase",
+        class: "w-full px-4 py-3 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-center text-2xl tracking-widest font-mono uppercase",
         placeholder: "ABC-123" %>
-    <p class="mt-2 text-sm text-gray-500">Code expires in 15 minutes</p>
+    <p class="mt-2 text-sm text-warm-500">Code expires in 15 minutes</p>
   </div>
 
   <div>
     <%= f.submit "Verify",
-        class: "w-full bg-emerald-600 text-white py-2 px-4 rounded-lg hover:bg-emerald-700 focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 font-medium transition-colors cursor-pointer" %>
+        class: "w-full bg-primary-600 text-white py-2 px-4 rounded-lg hover:bg-primary-700 focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 font-medium transition-colors cursor-pointer" %>
   </div>
 <% end %>
 
 <div class="mt-6 text-center">
-  <%= link_to "← Back to sign in", new_session_path, class: "text-gray-600 hover:text-gray-800" %>
+  <%= link_to "← Back to sign in", new_session_path, class: "text-warm-600 hover:text-warm-800" %>
 </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,29 +1,29 @@
 <% content_for(:title, "Sign in - MealSzn") %>
 
-<h2 class="text-2xl font-bold text-gray-900 mb-6 text-center">Sign in to MealSzn</h2>
+<h2 class="text-2xl font-display font-bold text-warm-900 mb-6 text-center">Sign in to MealSzn</h2>
 
 <%= form_with url: session_path, method: :post, class: "space-y-6" do |f| %>
   <div>
-    <%= f.label :email_address, "Email address", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.label :email_address, "Email address", class: "block text-sm font-medium text-warm-700 mb-1" %>
     <%= f.email_field :email_address,
         required: true,
         autofocus: true,
         autocomplete: "email",
-        class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500",
+        class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500",
         placeholder: "you@example.com" %>
   </div>
 
   <div>
     <%= f.submit "Send sign-in code",
-        class: "w-full bg-emerald-600 text-white py-2 px-4 rounded-lg hover:bg-emerald-700 focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 font-medium transition-colors cursor-pointer" %>
+        class: "w-full bg-primary-600 text-white py-2 px-4 rounded-lg hover:bg-primary-700 focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 font-medium transition-colors cursor-pointer" %>
   </div>
 <% end %>
 
 <% if Account.accepting_signups? %>
-  <div class="mt-6 pt-6 border-t border-gray-200 text-center">
-    <p class="text-gray-600">
+  <div class="mt-6 pt-6 border-t border-warm-200 text-center">
+    <p class="text-warm-600">
       Don't have an account?
-      <%= link_to "Sign up", new_signup_path, class: "text-emerald-600 hover:text-emerald-700 font-medium" %>
+      <%= link_to "Sign up", new_signup_path, class: "text-primary-600 hover:text-primary-700 font-medium" %>
     </p>
   </div>
 <% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,9 +1,9 @@
-<nav class="bg-emerald-600" data-controller="mobile-nav">
+<nav class="nav-warm" data-controller="mobile-nav">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex items-center justify-between h-16">
       <div class="flex items-center">
         <div class="shrink-0">
-          <%= link_to "MealSzn", account_root_path, class: "text-white font-bold text-xl" %>
+          <%= link_to "MealSzn", account_root_path, class: "text-white font-display font-bold text-xl" %>
         </div>
         <div class="hidden md:block">
           <div class="ml-10 flex items-baseline space-x-4">
@@ -16,7 +16,7 @@
 
       <%# Desktop user menu %>
       <div class="hidden md:block" data-controller="dropdown">
-        <button type="button" data-action="dropdown#toggle" class="flex items-center text-emerald-100 hover:text-white text-sm font-medium focus:outline-none">
+        <button type="button" data-action="dropdown#toggle" class="flex items-center text-primary-100 hover:text-white text-sm font-medium focus:outline-none">
           <span><%= Current.user.name %></span>
           <svg class="ml-1 h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
             <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
@@ -25,18 +25,18 @@
 
         <div data-dropdown-target="menu" class="hidden absolute right-4 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50">
           <div class="py-1">
-            <div class="px-4 py-2 text-xs text-gray-500"><%= Current.identity.email_address %></div>
-            <hr class="border-gray-100">
-            <%= link_to "Settings", settings_path, class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
-            <hr class="border-gray-100">
-            <%= button_to "Sign Out", session_path, method: :delete, class: "w-full text-left block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
+            <div class="px-4 py-2 text-xs text-warm-500"><%= Current.identity.email_address %></div>
+            <hr class="border-warm-100">
+            <%= link_to "Settings", settings_path, class: "block px-4 py-2 text-sm text-warm-700 hover:bg-warm-100" %>
+            <hr class="border-warm-100">
+            <%= button_to "Sign Out", session_path, method: :delete, class: "w-full text-left block px-4 py-2 text-sm text-warm-700 hover:bg-warm-100" %>
           </div>
         </div>
       </div>
 
       <%# Mobile hamburger button %>
       <div class="md:hidden">
-        <button type="button" data-action="mobile-nav#toggle" class="inline-flex items-center justify-center p-2 rounded-md text-emerald-200 hover:text-white hover:bg-emerald-500 focus:outline-none">
+        <button type="button" data-action="mobile-nav#toggle" class="inline-flex items-center justify-center p-2 rounded-md text-primary-200 hover:text-white hover:bg-primary-600 focus:outline-none">
           <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
           </svg>
@@ -52,14 +52,14 @@
       <%= nav_link_to "Recipes", recipes_path, controller_match: %w[recipes] %>
       <%= nav_link_to "Meal Plans", meal_plans_path, controller_match: %w[meal_plans meal_plan_meals shopping_lists shopping_list_items] %>
     </div>
-    <div class="border-t border-emerald-500 pt-4 pb-3">
+    <div class="border-t border-primary-600 pt-4 pb-3">
       <div class="px-4">
         <div class="text-base font-medium text-white"><%= Current.user.name %></div>
-        <div class="text-sm text-emerald-200"><%= Current.identity.email_address %></div>
+        <div class="text-sm text-primary-200"><%= Current.identity.email_address %></div>
       </div>
       <div class="mt-3 px-2 space-y-1">
-        <%= link_to "Settings", settings_path, class: "block rounded-md px-3 py-2 text-base font-medium text-emerald-200 hover:bg-emerald-500 hover:text-white" %>
-        <%= button_to "Sign Out", session_path, method: :delete, class: "w-full text-left block rounded-md px-3 py-2 text-base font-medium text-emerald-200 hover:bg-emerald-500 hover:text-white" %>
+        <%= link_to "Settings", settings_path, class: "block rounded-md px-3 py-2 text-base font-medium text-primary-200 hover:bg-primary-600 hover:text-white" %>
+        <%= button_to "Sign Out", session_path, method: :delete, class: "w-full text-left block rounded-md px-3 py-2 text-base font-medium text-primary-200 hover:bg-primary-600 hover:text-white" %>
       </div>
     </div>
   </div>

--- a/app/views/signups/completions/new.html.erb
+++ b/app/views/signups/completions/new.html.erb
@@ -1,25 +1,25 @@
 <% content_for(:title, "Complete your profile - MealSzn") %>
 
-<h2 class="text-2xl font-bold text-gray-900 mb-2 text-center">Complete your profile</h2>
+<h2 class="text-2xl font-display font-bold text-warm-900 mb-2 text-center">Complete your profile</h2>
 
-<p class="text-gray-600 mb-6 text-center">
+<p class="text-warm-600 mb-6 text-center">
   Tell us a bit about yourself
 </p>
 
 <%= form_with model: @signup, url: signup_completion_path, method: :post, class: "space-y-6" do |f| %>
   <div>
-    <%= f.label :full_name, "Your name", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.label :full_name, "Your name", class: "block text-sm font-medium text-warm-700 mb-1" %>
     <%= f.text_field :full_name,
         required: true,
         autofocus: true,
         autocomplete: "name",
         name: "full_name",
-        class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500",
+        class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500",
         placeholder: "Jane Smith" %>
   </div>
 
   <div>
     <%= f.submit "Create account",
-        class: "w-full bg-emerald-600 text-white py-2 px-4 rounded-lg hover:bg-emerald-700 focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 font-medium transition-colors cursor-pointer" %>
+        class: "w-full bg-primary-600 text-white py-2 px-4 rounded-lg hover:bg-primary-700 focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 font-medium transition-colors cursor-pointer" %>
   </div>
 <% end %>

--- a/app/views/signups/new.html.erb
+++ b/app/views/signups/new.html.erb
@@ -1,27 +1,27 @@
 <% content_for(:title, "Sign up - MealSzn") %>
 
-<h2 class="text-2xl font-bold text-gray-900 mb-6 text-center">Create your account</h2>
+<h2 class="text-2xl font-display font-bold text-warm-900 mb-6 text-center">Create your account</h2>
 
 <%= form_with url: signup_path, method: :post, class: "space-y-6" do |f| %>
   <div>
-    <%= f.label :email_address, "Email address", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.label :email_address, "Email address", class: "block text-sm font-medium text-warm-700 mb-1" %>
     <%= f.email_field :email_address,
         required: true,
         autofocus: true,
         autocomplete: "email",
-        class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500",
+        class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500",
         placeholder: "you@example.com" %>
   </div>
 
   <div>
     <%= f.submit "Continue",
-        class: "w-full bg-emerald-600 text-white py-2 px-4 rounded-lg hover:bg-emerald-700 focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 font-medium transition-colors cursor-pointer" %>
+        class: "w-full bg-primary-600 text-white py-2 px-4 rounded-lg hover:bg-primary-700 focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 font-medium transition-colors cursor-pointer" %>
   </div>
 <% end %>
 
-<div class="mt-6 pt-6 border-t border-gray-200 text-center">
-  <p class="text-gray-600">
+<div class="mt-6 pt-6 border-t border-warm-200 text-center">
+  <p class="text-warm-600">
     Already have an account?
-    <%= link_to "Sign in", new_session_path, class: "text-emerald-600 hover:text-emerald-700 font-medium" %>
+    <%= link_to "Sign in", new_session_path, class: "text-primary-600 hover:text-primary-700 font-medium" %>
   </p>
 </div>


### PR DESCRIPTION
## Summary

Replace Tailwind defaults (system fonts, emerald-on-gray) with a distinctive warm design system that evokes food, warmth, and family meal planning. This establishes the visual identity for MealSzn.

## Changes

- **Fonts**: Bitter (slab-serif display) + Nunito Sans (body) loaded via Google Fonts in both layouts
- **Color system**: Terracotta primary (`primary-*`), saffron accent (`accent-*`), warm neutrals (`warm-*`) defined as Tailwind v4 `@theme` tokens in `application.css`
- **Custom CSS**: `.bg-warm-gradient` body background, `.card-warm` frosted glass cards, `.nav-warm` gradient navbar
- **35+ view files** updated: all `emerald-*` → `primary-*`, `gray-*` → `warm-*`, `blue-*` → `accent-*`
- **Navigation helper** updated with new color tokens
- **Rubocop**: Added `app/assets/**/*` exclusion to prevent CSS file parsing errors
- **CLAUDE.md**: Documented the full design system (tokens, fonts, conventions)

## Documentation

- CLAUDE.md: Added Design System section with color tokens, font choices, custom classes, and conventions
- README.md: No changes needed (no setup/behavior changes)

## Testing

- All 533 tests pass
- Rubocop: clean (no new offenses)
- Brakeman: clean (pre-existing warning only)
- Bundle audit + importmap audit: no vulnerabilities
- Start `bin/dev` and review all pages visually for color/font consistency

Closes #32