### PR TITLE
Add Anthropic (Claude) AI integration service layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,19 @@ All primary keys are string UUIDs. Key models:
 
 Controllers under `app/controllers/accounts/api/v1/` inherit from `ActionController::API` (no views). Recipes expose `to_api_response` and `to_meal_planning_response` serialization methods directly on the model.
 
+### AI Service Layer
+
+`Ai::Client` (`app/services/ai/client.rb`) wraps the Anthropic Claude API via the `anthropic` gem. Configured in `config/initializers/ai.rb` (default model: `claude-sonnet-4-20250514`).
+
+**Methods:**
+- `chat(messages:, system:, max_tokens:)` — text completion
+- `chat_with_tools(messages:, tools:, system:, max_tokens:)` — structured JSON via tool_use
+- `vision(messages:, system:, max_tokens:)` — image + text input
+
+**Credentials:** `Rails.application.credentials.dig(:ai, :anthropic, :api_key)`
+
+**Error handling:** Retries 3× with exponential backoff (1s/2s/4s) on rate limits, server errors, and timeouts. Custom exceptions: `Ai::Client::ApiError`, `RateLimitError`, `TimeoutError`, `AuthenticationError`.
+
 ### Design System
 
 Defined in `app/assets/tailwind/application.css` using Tailwind v4 `@theme` block.

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,9 @@ gem "thruster", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 1.2"
 
+# Anthropic Claude API client [https://github.com/alexrudall/anthropic]
+gem "anthropic"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,9 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
+    anthropic (1.23.0)
+      cgi
+      connection_pool
     ast (2.4.3)
     base64 (0.3.0)
     bcrypt_pbkdf (1.1.2)
@@ -99,6 +102,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cgi (0.5.1)
     childprocess (5.1.0)
       logger (~> 1.5)
     concurrent-ruby (1.3.6)
@@ -406,6 +410,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  anthropic
   bootsnap
   brakeman
   bundler-audit
@@ -446,6 +451,7 @@ CHECKSUMS
   activestorage (8.1.2) sha256=8a63a48c3999caeee26a59441f813f94681fc35cc41aba7ce1f836add04fba76
   activesupport (8.1.2) sha256=88842578ccd0d40f658289b0e8c842acfe9af751afee2e0744a7873f50b6fdae
   addressable (2.8.8) sha256=7c13b8f9536cf6364c03b9d417c19986019e28f7c00ac8132da4eb0fe393b057
+  anthropic (1.23.0) sha256=6290309d1f6488d132b6fd5a79d8d5414ef09f281d6668f930c2cd88658b9d82
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bcrypt_pbkdf (1.1.2) sha256=c2414c23ce66869b3eb9f643d6a3374d8322dfb5078125c82792304c10b94cf6
@@ -456,6 +462,7 @@ CHECKSUMS
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
+  cgi (0.5.1) sha256=e93fcafc69b8a934fe1e6146121fa35430efa8b4a4047c4893764067036f18e9
   childprocess (5.1.0) sha256=9a8d484be2fd4096a0e90a0cd3e449a05bc3aa33f8ac9e4d6dcef6ac1455b6ec
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a

--- a/app/services/ai/client.rb
+++ b/app/services/ai/client.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module Ai
+  class Client
+    class Error < StandardError; end
+    class ApiError < Error; end
+    class RateLimitError < ApiError; end
+    class TimeoutError < ApiError; end
+    class AuthenticationError < ApiError; end
+
+    MAX_RETRIES = 3
+    RETRY_DELAYS = [ 1, 2, 4 ].freeze
+
+    def initialize(api_key: nil, model: nil)
+      @api_key = api_key || Rails.application.credentials.dig(:ai, :anthropic, :api_key)
+      @model = model || Ai.default_model
+
+      raise AuthenticationError, "Anthropic API key is not configured" if @api_key.blank?
+    end
+
+    # Basic message completion
+    #
+    # @param messages [Array<Hash>] Conversation messages, e.g. [{role: "user", content: "Hello"}]
+    # @param system [String, nil] Optional system prompt
+    # @param max_tokens [Integer] Maximum tokens to generate
+    # @return [String] The assistant's text response
+    def chat(messages:, system: nil, max_tokens: 1024)
+      params = build_params(messages:, system:, max_tokens:)
+      response = with_retries { anthropic_client.messages.create(**params) }
+      extract_text(response)
+    end
+
+    # Message completion with tool use for structured JSON output
+    #
+    # @param messages [Array<Hash>] Conversation messages
+    # @param tools [Array<Hash>] Tool definitions with name, description, input_schema
+    # @param system [String, nil] Optional system prompt
+    # @param max_tokens [Integer] Maximum tokens to generate
+    # @return [Hash] Parsed tool input from the model's tool_use response
+    def chat_with_tools(messages:, tools:, system: nil, max_tokens: 4096)
+      params = build_params(messages:, system:, max_tokens:)
+      params[:tools] = tools
+      params[:tool_choice] = { type: "any" }
+
+      response = with_retries { anthropic_client.messages.create(**params) }
+      extract_tool_use(response)
+    end
+
+    # Vision-capable message completion (images + text)
+    #
+    # @param messages [Array<Hash>] Messages with image content blocks
+    # @param system [String, nil] Optional system prompt
+    # @param max_tokens [Integer] Maximum tokens to generate
+    # @return [String] The assistant's text response
+    def vision(messages:, system: nil, max_tokens: 1024)
+      chat(messages:, system:, max_tokens:)
+    end
+
+    private
+
+    def anthropic_client
+      @anthropic_client ||= Anthropic::Client.new(api_key: @api_key)
+    end
+
+    def build_params(messages:, system: nil, max_tokens:)
+      params = {
+        model: @model,
+        max_tokens: max_tokens,
+        messages: messages
+      }
+      params[:system] = system if system.present?
+      params
+    end
+
+    def with_retries(&block)
+      attempts = 0
+      begin
+        attempts += 1
+        yield
+      rescue Anthropic::Errors::RateLimitError, Anthropic::Errors::InternalServerError => e
+        raise RateLimitError, "Rate limit exceeded: #{e.message}" if attempts >= MAX_RETRIES
+        sleep RETRY_DELAYS[attempts - 1]
+        retry
+      rescue Anthropic::Errors::APITimeoutError => e
+        raise TimeoutError, "Request timed out: #{e.message}" if attempts >= MAX_RETRIES
+        sleep RETRY_DELAYS[attempts - 1]
+        retry
+      rescue Anthropic::Errors::AuthenticationError => e
+        raise AuthenticationError, "Authentication failed: #{e.message}"
+      rescue Anthropic::Errors::APIError => e
+        raise ApiError, "API error (#{e.status}): #{e.message}"
+      end
+    end
+
+    def extract_text(response)
+      response.content
+        .select { |block| block.type == "text" }
+        .map(&:text)
+        .join
+    end
+
+    def extract_tool_use(response)
+      tool_block = response.content.find { |block| block.type == "tool_use" }
+      raise ApiError, "No tool_use block in response" unless tool_block
+
+      { name: tool_block.name, input: tool_block.input.to_h }
+    end
+  end
+end

--- a/config/initializers/ai.rb
+++ b/config/initializers/ai.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Ai
+  mattr_accessor :default_model, default: "claude-sonnet-4-20250514"
+end

--- a/test/services/ai/client_test.rb
+++ b/test/services/ai/client_test.rb
@@ -1,0 +1,345 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Ai::ClientTest < ActiveSupport::TestCase
+  # Testable subclass that intercepts the Anthropic API call
+  class TestableClient < Ai::Client
+    attr_accessor :stub_responses, :call_count, :last_params
+
+    def initialize(stub_responses:, model: nil)
+      @stub_responses = Array(stub_responses)
+      @call_count = 0
+      @last_params = nil
+      super(api_key: "test-key", model: model)
+    end
+
+    private
+
+    def anthropic_client
+      @fake_client ||= FakeAnthropicClient.new(self)
+    end
+  end
+
+  # Minimal fake that mimics Anthropic::Client.messages.create
+  class FakeAnthropicClient
+    def initialize(testable_client)
+      @testable_client = testable_client
+    end
+
+    def messages
+      self
+    end
+
+    def create(**params)
+      @testable_client.last_params = params
+      index = @testable_client.call_count
+      @testable_client.call_count += 1
+      response = @testable_client.stub_responses[index] || @testable_client.stub_responses.last
+
+      raise response if response.is_a?(Exception)
+
+      response
+    end
+  end
+
+  # Simple struct to mimic Anthropic response content blocks
+  TextBlock = Struct.new(:type, :text, keyword_init: true)
+  ToolUseBlock = Struct.new(:type, :name, :input, keyword_init: true)
+
+  # Wraps a hash to respond to .to_h (like Anthropic tool input)
+  class FakeToolInput
+    def initialize(hash)
+      @hash = hash
+    end
+
+    def to_h
+      @hash
+    end
+  end
+
+  # Simple response object
+  class FakeResponse
+    attr_reader :content
+
+    def initialize(content:)
+      @content = content
+    end
+  end
+
+  # --- Initialization ---
+
+  test "raises AuthenticationError when API key is missing" do
+    assert_raises(Ai::Client::AuthenticationError) do
+      Ai::Client.new(api_key: nil)
+    end
+  end
+
+  test "initializes with provided API key" do
+    client = Ai::Client.new(api_key: "test-key")
+    assert_not_nil client
+  end
+
+  # --- chat ---
+
+  test "chat returns text content from response" do
+    response = FakeResponse.new(content: [
+      TextBlock.new(type: "text", text: "Hello! How can I help?")
+    ])
+
+    client = TestableClient.new(stub_responses: response)
+    result = client.chat(messages: [ { role: "user", content: "Hi" } ])
+
+    assert_equal "Hello! How can I help?", result
+  end
+
+  test "chat concatenates multiple text blocks" do
+    response = FakeResponse.new(content: [
+      TextBlock.new(type: "text", text: "Part one. "),
+      TextBlock.new(type: "text", text: "Part two.")
+    ])
+
+    client = TestableClient.new(stub_responses: response)
+    result = client.chat(messages: [ { role: "user", content: "Hi" } ])
+
+    assert_equal "Part one. Part two.", result
+  end
+
+  test "chat passes system prompt when provided" do
+    response = FakeResponse.new(content: [
+      TextBlock.new(type: "text", text: "response")
+    ])
+
+    client = TestableClient.new(stub_responses: response)
+    client.chat(messages: [ { role: "user", content: "Hi" } ], system: "You are a chef.")
+
+    assert_equal "You are a chef.", client.last_params[:system]
+  end
+
+  test "chat omits system key when not provided" do
+    response = FakeResponse.new(content: [
+      TextBlock.new(type: "text", text: "response")
+    ])
+
+    client = TestableClient.new(stub_responses: response)
+    client.chat(messages: [ { role: "user", content: "Hi" } ])
+
+    assert_not client.last_params.key?(:system)
+  end
+
+  test "chat uses default max_tokens of 1024" do
+    response = FakeResponse.new(content: [
+      TextBlock.new(type: "text", text: "response")
+    ])
+
+    client = TestableClient.new(stub_responses: response)
+    client.chat(messages: [ { role: "user", content: "Hi" } ])
+
+    assert_equal 1024, client.last_params[:max_tokens]
+  end
+
+  # --- chat_with_tools ---
+
+  test "chat_with_tools returns parsed tool use block" do
+    tool_input = FakeToolInput.new({ "recipe_name" => "Keto Pancakes", "calories" => 350 })
+    response = FakeResponse.new(content: [
+      ToolUseBlock.new(type: "tool_use", name: "generate_recipe", input: tool_input)
+    ])
+
+    tools = [ {
+      name: "generate_recipe",
+      description: "Generate a recipe",
+      input_schema: {
+        type: "object",
+        properties: { recipe_name: { type: "string" }, calories: { type: "integer" } },
+        required: [ "recipe_name" ]
+      }
+    } ]
+
+    client = TestableClient.new(stub_responses: response)
+    result = client.chat_with_tools(
+      messages: [ { role: "user", content: "Give me a keto pancake recipe" } ],
+      tools: tools
+    )
+
+    assert_equal "generate_recipe", result[:name]
+    assert_equal "Keto Pancakes", result[:input]["recipe_name"]
+    assert_equal 350, result[:input]["calories"]
+  end
+
+  test "chat_with_tools sends tool_choice any" do
+    tool_input = FakeToolInput.new({})
+    response = FakeResponse.new(content: [
+      ToolUseBlock.new(type: "tool_use", name: "test_tool", input: tool_input)
+    ])
+
+    client = TestableClient.new(stub_responses: response)
+    client.chat_with_tools(
+      messages: [ { role: "user", content: "test" } ],
+      tools: [ { name: "test_tool", description: "test", input_schema: { type: "object", properties: {} } } ]
+    )
+
+    assert_equal({ type: "any" }, client.last_params[:tool_choice])
+  end
+
+  test "chat_with_tools raises ApiError when no tool_use block in response" do
+    response = FakeResponse.new(content: [
+      TextBlock.new(type: "text", text: "I can't use tools")
+    ])
+
+    client = TestableClient.new(stub_responses: response)
+
+    error = assert_raises(Ai::Client::ApiError) do
+      client.chat_with_tools(
+        messages: [ { role: "user", content: "test" } ],
+        tools: [ { name: "test_tool", description: "test", input_schema: { type: "object", properties: {} } } ]
+      )
+    end
+
+    assert_match(/No tool_use block/, error.message)
+  end
+
+  # --- vision ---
+
+  test "vision returns text response for image messages" do
+    response = FakeResponse.new(content: [
+      TextBlock.new(type: "text", text: "I see a delicious steak")
+    ])
+
+    client = TestableClient.new(stub_responses: response)
+    messages = [ {
+      role: "user",
+      content: [
+        { type: "image", source: { type: "base64", media_type: "image/jpeg", data: "abc123" } },
+        { type: "text", text: "What food is in this image?" }
+      ]
+    } ]
+
+    result = client.vision(messages: messages)
+    assert_equal "I see a delicious steak", result
+  end
+
+  # --- Error handling and retries ---
+
+  test "retries on rate limit error and eventually raises" do
+    rate_limit_error = Anthropic::Errors::RateLimitError.new(
+      url: URI("https://api.anthropic.com/v1/messages"),
+      status: 429,
+      headers: {},
+      body: "rate limited",
+      request: nil,
+      response: nil
+    )
+
+    client = TestableClient.new(stub_responses: [ rate_limit_error, rate_limit_error, rate_limit_error ])
+    client.define_singleton_method(:sleep) { |_| } # no-op sleep
+
+    assert_raises(Ai::Client::RateLimitError) do
+      client.chat(messages: [ { role: "user", content: "Hi" } ])
+    end
+
+    assert_equal 3, client.call_count
+  end
+
+  test "retries on server error and succeeds on final attempt" do
+    server_error = Anthropic::Errors::InternalServerError.new(
+      url: URI("https://api.anthropic.com/v1/messages"),
+      status: 500,
+      headers: {},
+      body: "server error",
+      request: nil,
+      response: nil
+    )
+    success = FakeResponse.new(content: [
+      TextBlock.new(type: "text", text: "Success after retry")
+    ])
+
+    client = TestableClient.new(stub_responses: [ server_error, server_error, success ])
+    client.define_singleton_method(:sleep) { |_| }
+
+    result = client.chat(messages: [ { role: "user", content: "Hi" } ])
+
+    assert_equal "Success after retry", result
+    assert_equal 3, client.call_count
+  end
+
+  test "retries on timeout and eventually raises" do
+    timeout_error = Anthropic::Errors::APITimeoutError.new(
+      url: URI("https://api.anthropic.com/v1/messages"),
+      request: nil,
+      response: nil
+    )
+
+    client = TestableClient.new(stub_responses: [ timeout_error, timeout_error, timeout_error ])
+    client.define_singleton_method(:sleep) { |_| }
+
+    assert_raises(Ai::Client::TimeoutError) do
+      client.chat(messages: [ { role: "user", content: "Hi" } ])
+    end
+
+    assert_equal 3, client.call_count
+  end
+
+  test "does not retry authentication errors" do
+    auth_error = Anthropic::Errors::AuthenticationError.new(
+      url: URI("https://api.anthropic.com/v1/messages"),
+      status: 401,
+      headers: {},
+      body: "invalid key",
+      request: nil,
+      response: nil
+    )
+
+    client = TestableClient.new(stub_responses: [ auth_error ])
+
+    assert_raises(Ai::Client::AuthenticationError) do
+      client.chat(messages: [ { role: "user", content: "Hi" } ])
+    end
+
+    assert_equal 1, client.call_count
+  end
+
+  test "wraps generic API errors" do
+    bad_request = Anthropic::Errors::BadRequestError.new(
+      url: URI("https://api.anthropic.com/v1/messages"),
+      status: 400,
+      headers: {},
+      body: "bad request",
+      request: nil,
+      response: nil
+    )
+
+    client = TestableClient.new(stub_responses: [ bad_request ])
+
+    error = assert_raises(Ai::Client::ApiError) do
+      client.chat(messages: [ { role: "user", content: "Hi" } ])
+    end
+
+    assert_match(/400/, error.message)
+    assert_equal 1, client.call_count
+  end
+
+  # --- Model configuration ---
+
+  test "uses default model from initializer" do
+    response = FakeResponse.new(content: [
+      TextBlock.new(type: "text", text: "response")
+    ])
+
+    client = TestableClient.new(stub_responses: response)
+    client.chat(messages: [ { role: "user", content: "Hi" } ])
+
+    assert_equal "claude-sonnet-4-20250514", client.last_params[:model]
+  end
+
+  test "uses custom model when provided" do
+    response = FakeResponse.new(content: [
+      TextBlock.new(type: "text", text: "response")
+    ])
+
+    client = TestableClient.new(stub_responses: response, model: "claude-haiku-4-5-20251001")
+    client.chat(messages: [ { role: "user", content: "Hi" } ])
+
+    assert_equal "claude-haiku-4-5-20251001", client.last_params[:model]
+  end
+end


### PR DESCRIPTION
## Summary

Adds a foundational `Ai::Client` service layer wrapping the Anthropic Claude API for use across all AI-powered features (meal planning, recipe generation, auto-categorization).

## Changes

- Added `anthropic` gem to Gemfile
- Created `Ai::Client` (`app/services/ai/client.rb`) with `chat`, `chat_with_tools`, and `vision` methods
- Structured JSON output via Claude's native `tool_use` pattern
- Exponential backoff retry (3 attempts, 1s/2s/4s delays) for rate limits, server errors, and timeouts
- Custom exception hierarchy: `ApiError`, `RateLimitError`, `TimeoutError`, `AuthenticationError`
- API key stored in Rails credentials under `ai.anthropic.api_key`
- `config/initializers/ai.rb` configures default model (`claude-sonnet-4-20250514`)
- 18 unit tests with stubbed API responses (subclass pattern matching existing `Usda::Client` tests)
- Updated CLAUDE.md with AI service layer documentation

## Testing

- `bin/rails test test/services/ai/client_test.rb` — 18 tests, all passing
- Full suite: 551 tests, 0 failures
- Rubocop: 0 offenses
- Brakeman: 1 pre-existing weak warning (HTTP verb confusion, not introduced here)
- bundler-audit / importmap audit: clean

Closes #6