### PR TITLE
Add macro visualization (donut charts and progress bars)

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -68,3 +68,9 @@
 .nav-warm {
   background: linear-gradient(135deg, #7d381c 0%, #a14722 40%, #c2582a 100%);
 }
+
+/* Macro donut chart — ring mask */
+.macro-donut {
+  -webkit-mask: radial-gradient(circle, transparent 55%, black 56%);
+  mask: radial-gradient(circle, transparent 55%, black 56%);
+}

--- a/app/helpers/nutrition_helper.rb
+++ b/app/helpers/nutrition_helper.rb
@@ -1,0 +1,127 @@
+module NutritionHelper
+  MACRO_COLORS = {
+    fat: "#F59E0B",
+    protein: "#14B8A6",
+    carbs: "#F87171"
+  }.freeze
+
+  MACRO_BG_COLORS = {
+    fat: "bg-amber-500",
+    protein: "bg-teal-500",
+    carbs: "bg-red-400"
+  }.freeze
+
+  MACRO_LIGHT_BG = {
+    fat: "bg-amber-100",
+    protein: "bg-teal-100",
+    carbs: "bg-red-100"
+  }.freeze
+
+  def macro_donut_chart(fat_g:, protein_g:, carbs_g:, size: 80)
+    fat_cal = fat_g.to_f * 9
+    protein_cal = protein_g.to_f * 4
+    carbs_cal = carbs_g.to_f * 4
+    total_cal = fat_cal + protein_cal + carbs_cal
+
+    return empty_donut(size) if total_cal.zero?
+
+    fat_pct = (fat_cal / total_cal * 100).round
+    protein_pct = (protein_cal / total_cal * 100).round
+    carbs_pct = 100 - fat_pct - protein_pct
+
+    fat_end = fat_pct
+    protein_end = fat_end + protein_pct
+
+    content_tag(:div, class: "inline-flex flex-col items-center gap-2") do
+      content_tag(:div, "",
+        class: "macro-donut rounded-full shrink-0",
+        style: "width: #{size}px; height: #{size}px; " \
+               "background: conic-gradient(" \
+               "#{MACRO_COLORS[:fat]} 0% #{fat_end}%, " \
+               "#{MACRO_COLORS[:protein]} #{fat_end}% #{protein_end}%, " \
+               "#{MACRO_COLORS[:carbs]} #{protein_end}% 100%);") +
+      content_tag(:div, class: "flex gap-3 text-xs") do
+        macro_legend_item(:fat, fat_pct) +
+        macro_legend_item(:protein, protein_pct) +
+        macro_legend_item(:carbs, carbs_pct)
+      end
+    end
+  end
+
+  def macro_progress_bar(actual:, target:, label:, macro_key:, unit: "g")
+    color = MACRO_BG_COLORS[macro_key] || "bg-warm-500"
+    light = MACRO_LIGHT_BG[macro_key] || "bg-warm-100"
+    status = macro_bar_status_class(actual, target)
+
+    pct = target && target > 0 ? [ (actual.to_f / target * 100).round, 100 ].min : 0
+
+    content_tag(:div, class: "flex items-center gap-2 text-xs") do
+      content_tag(:span, label, class: "w-12 font-medium text-warm-600 shrink-0") +
+      content_tag(:div, class: "flex-1 #{light} rounded-full h-2.5 overflow-hidden") do
+        content_tag(:div, "", class: "h-full rounded-full #{status}", style: "width: #{pct}%")
+      end +
+      content_tag(:span, class: "w-24 text-right text-warm-600 tabular-nums shrink-0") do
+        if target && target > 0
+          raw("#{actual.is_a?(Float) ? actual.round(1) : actual}#{unit} / #{target.is_a?(Float) ? target.round(1) : target}#{unit}")
+        else
+          raw("#{actual.is_a?(Float) ? actual.round(1) : actual}#{unit}")
+        end
+      end
+    end
+  end
+
+  def diet_compatibility_badge(nutrition_data)
+    return nil unless nutrition_data&.calories&.positive?
+
+    carb_cal = nutrition_data.net_carbs.to_f * 4
+    total_cal = nutrition_data.calories.to_f
+
+    carb_pct = carb_cal / total_cal * 100
+
+    badges = []
+    if carb_pct <= 10
+      badges << content_tag(:span, "Keto", class: "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800")
+    elsif carb_pct <= 25
+      badges << content_tag(:span, "Low-Carb", class: "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-teal-100 text-teal-800")
+    end
+
+    if nutrition_data.protein.to_f * 4 / total_cal * 100 >= 30
+      badges << content_tag(:span, "High-Protein", class: "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800")
+    end
+
+    return nil if badges.empty?
+    safe_join(badges, " ")
+  end
+
+  def mini_donut_chart(fat_g:, protein_g:, carbs_g:)
+    macro_donut_chart(fat_g: fat_g, protein_g: protein_g, carbs_g: carbs_g, size: 48)
+  end
+
+  private
+
+  def empty_donut(size)
+    content_tag(:div, "",
+      class: "rounded-full bg-warm-200 shrink-0",
+      style: "width: #{size}px; height: #{size}px;")
+  end
+
+  def macro_legend_item(macro, pct)
+    content_tag(:span, class: "flex items-center gap-1") do
+      content_tag(:span, "", class: "inline-block w-2 h-2 rounded-full", style: "background: #{MACRO_COLORS[macro]}") +
+      content_tag(:span, "#{macro.to_s.capitalize} #{pct}%", class: "text-warm-600")
+    end
+  end
+
+  def macro_bar_status_class(actual, target)
+    return "bg-warm-400" unless target && target > 0
+
+    ratio = actual.to_f / target
+    if ratio >= 0.9 && ratio <= 1.1
+      "bg-green-500"
+    elsif ratio >= 0.75 && ratio <= 1.25
+      "bg-amber-500"
+    else
+      "bg-red-400"
+    end
+  end
+end

--- a/app/views/accounts/dietary_profiles/index.html.erb
+++ b/app/views/accounts/dietary_profiles/index.html.erb
@@ -11,32 +11,44 @@
   </div>
 
   <% if @dietary_profiles.any? %>
-    <div class="bg-white rounded-lg shadow overflow-hidden">
-      <table class="min-w-full divide-y divide-warm-200">
-        <thead class="bg-warm-50">
-          <tr>
-            <th class="px-6 py-3 text-left text-xs font-medium text-warm-500 uppercase tracking-wider">Name</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-warm-500 uppercase tracking-wider">Diet</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-warm-500 uppercase tracking-wider">Daily Calories</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-warm-500 uppercase tracking-wider">Linked User</th>
-            <th class="px-6 py-3 text-right text-xs font-medium text-warm-500 uppercase tracking-wider">Actions</th>
-          </tr>
-        </thead>
-        <tbody class="bg-white divide-y divide-warm-200">
-          <% @dietary_profiles.each do |profile| %>
-            <tr>
-              <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-warm-900"><%= profile.name %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-warm-500"><%= profile.diet_name.presence || "None" %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-warm-500"><%= profile.daily_calories_target ? "#{profile.daily_calories_target} cal" : "Not set" %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-warm-500"><%= profile.user&.name || "—" %></td>
-              <td class="px-6 py-4 whitespace-nowrap text-right text-sm">
-                <%= link_to "Edit", edit_dietary_profile_path(profile), class: "text-primary-600 hover:text-primary-700 font-medium mr-3" %>
-                <%= button_to "Remove", dietary_profile_path(profile), method: :delete, class: "text-red-600 hover:text-red-700 font-medium", data: { turbo_confirm: "Remove this dietary profile?" } %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
+    <div class="space-y-4">
+      <% @dietary_profiles.each do |profile| %>
+        <div class="bg-white rounded-lg shadow p-5">
+          <div class="flex items-start gap-5">
+            <% targets = profile.macro_targets %>
+            <% if targets && targets[:fat_g] && targets[:protein_g] && targets[:carbs_g] %>
+              <%= mini_donut_chart(fat_g: targets[:fat_g], protein_g: targets[:protein_g], carbs_g: targets[:carbs_g]) %>
+            <% end %>
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center justify-between mb-1">
+                <h3 class="text-lg font-semibold text-warm-900"><%= profile.name %></h3>
+                <div class="flex items-center gap-3 text-sm shrink-0">
+                  <%= link_to "Edit", edit_dietary_profile_path(profile), class: "text-primary-600 hover:text-primary-700 font-medium" %>
+                  <%= button_to "Remove", dietary_profile_path(profile), method: :delete, class: "text-red-600 hover:text-red-700 font-medium", data: { turbo_confirm: "Remove this dietary profile?" } %>
+                </div>
+              </div>
+              <div class="flex flex-wrap items-center gap-3 text-sm text-warm-500">
+                <% if profile.diet_name.present? %>
+                  <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary-100 text-primary-800"><%= profile.diet_name %></span>
+                <% end %>
+                <% if profile.daily_calories_target %>
+                  <span><%= profile.daily_calories_target %> cal/day</span>
+                <% end %>
+                <% if profile.user %>
+                  <span>Linked to <%= profile.user.name %></span>
+                <% end %>
+              </div>
+              <% if targets && targets[:fat_g] %>
+                <div class="flex gap-4 mt-2 text-xs text-warm-500">
+                  <span>Fat: <strong class="text-warm-700"><%= targets[:fat_g] %>g</strong></span>
+                  <span>Protein: <strong class="text-warm-700"><%= targets[:protein_g] %>g</strong></span>
+                  <span>Carbs: <strong class="text-warm-700"><%= targets[:carbs_g] %>g</strong></span>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      <% end %>
     </div>
   <% else %>
     <div class="bg-white rounded-lg shadow px-6 py-12 text-center">

--- a/app/views/accounts/meal_plans/_day_card.html.erb
+++ b/app/views/accounts/meal_plans/_day_card.html.erb
@@ -62,26 +62,20 @@
   <% if defined?(participants) && participants&.any? && day.meals.any? %>
     <div class="px-6 py-4 border-t border-warm-200 bg-warm-50 rounded-b-lg">
       <h4 class="text-xs font-semibold text-warm-500 uppercase tracking-wider mb-3">Daily Macros by Participant</h4>
-      <div class="space-y-2">
+      <div class="space-y-4">
         <% participants.each_with_index do |participant, p_idx| %>
           <% totals = participant.daily_totals_for(day) %>
           <% targets = participant.macro_targets %>
-          <div class="flex items-center gap-3 text-sm">
-            <span class="inline-block w-3 h-3 rounded-full shrink-0" style="background-color: <%= participant_color(p_idx) %>"></span>
-            <span class="font-medium text-warm-900 w-20 truncate"><%= participant.name %></span>
-            <div class="flex gap-4 text-xs">
-              <span class="<%= macro_status_class(totals[:calories], targets&.dig(:calories)) %>">
-                Cal: <%= totals[:calories].round %><%= "/#{targets[:calories]}" if targets&.dig(:calories) %>
-              </span>
-              <span class="<%= macro_status_class(totals[:fat_g], targets&.dig(:fat_g)) %>">
-                Fat: <%= totals[:fat_g].round(1) %>g<%= "/#{targets[:fat_g]}g" if targets&.dig(:fat_g) %>
-              </span>
-              <span class="<%= macro_status_class(totals[:protein_g], targets&.dig(:protein_g)) %>">
-                Protein: <%= totals[:protein_g].round(1) %>g<%= "/#{targets[:protein_g]}g" if targets&.dig(:protein_g) %>
-              </span>
-              <span class="<%= macro_status_class(totals[:net_carbs_g], targets&.dig(:carbs_g)) %>">
-                Carbs: <%= totals[:net_carbs_g].round(1) %>g<%= "/#{targets[:carbs_g]}g" if targets&.dig(:carbs_g) %>
-              </span>
+          <div>
+            <div class="flex items-center gap-2 mb-2">
+              <span class="inline-block w-3 h-3 rounded-full shrink-0" style="background-color: <%= participant_color(p_idx) %>"></span>
+              <span class="font-medium text-warm-900 text-sm"><%= participant.name %></span>
+            </div>
+            <div class="space-y-1.5 ml-5">
+              <%= macro_progress_bar(actual: totals[:calories].round, target: targets&.dig(:calories), label: "Cal", macro_key: nil, unit: "") %>
+              <%= macro_progress_bar(actual: totals[:fat_g], target: targets&.dig(:fat_g), label: "Fat", macro_key: :fat) %>
+              <%= macro_progress_bar(actual: totals[:protein_g], target: targets&.dig(:protein_g), label: "Protein", macro_key: :protein) %>
+              <%= macro_progress_bar(actual: totals[:net_carbs_g], target: targets&.dig(:carbs_g), label: "Carbs", macro_key: :carbs) %>
             </div>
           </div>
         <% end %>

--- a/app/views/accounts/recipes/show.html.erb
+++ b/app/views/accounts/recipes/show.html.erb
@@ -47,13 +47,24 @@
 
     <% if @recipe.nutrition_data %>
       <div class="p-6 border-b border-warm-200 bg-warm-50">
-        <h2 class="text-sm font-semibold text-warm-500 uppercase tracking-wider mb-3">Nutrition per Serving</h2>
-        <div class="grid grid-cols-2 md:grid-cols-5 gap-4">
-          <div><span class="text-2xl font-display font-bold text-warm-900"><%= @recipe.nutrition_data.calories %></span><br><span class="text-xs text-warm-500">Calories</span></div>
-          <div><span class="text-2xl font-display font-bold text-warm-900"><%= @recipe.nutrition_data.fat %>g</span><br><span class="text-xs text-warm-500">Fat</span></div>
-          <div><span class="text-2xl font-display font-bold text-warm-900"><%= @recipe.nutrition_data.protein %>g</span><br><span class="text-xs text-warm-500">Protein</span></div>
-          <div><span class="text-2xl font-display font-bold text-warm-900"><%= @recipe.nutrition_data.net_carbs %>g</span><br><span class="text-xs text-warm-500">Net Carbs</span></div>
-          <div><span class="text-2xl font-display font-bold text-warm-900"><%= @recipe.nutrition_data.fiber %>g</span><br><span class="text-xs text-warm-500">Fiber</span></div>
+        <div class="flex items-center justify-between mb-3">
+          <h2 class="text-sm font-semibold text-warm-500 uppercase tracking-wider">Nutrition per Serving</h2>
+          <% if (badge = diet_compatibility_badge(@recipe.nutrition_data)) %>
+            <div class="flex gap-1.5"><%= badge %></div>
+          <% end %>
+        </div>
+        <div class="flex items-start gap-8">
+          <% nd = @recipe.nutrition_data %>
+          <% if nd.fat.present? && nd.protein.present? && nd.net_carbs.present? %>
+            <%= macro_donut_chart(fat_g: nd.fat, protein_g: nd.protein, carbs_g: nd.net_carbs) %>
+          <% end %>
+          <div class="flex-1 grid grid-cols-2 md:grid-cols-5 gap-4">
+            <div><span class="text-2xl font-display font-bold text-warm-900"><%= nd.calories %></span><br><span class="text-xs text-warm-500">Calories</span></div>
+            <div><span class="text-2xl font-display font-bold text-warm-900"><%= nd.fat %>g</span><br><span class="text-xs text-warm-500">Fat</span></div>
+            <div><span class="text-2xl font-display font-bold text-warm-900"><%= nd.protein %>g</span><br><span class="text-xs text-warm-500">Protein</span></div>
+            <div><span class="text-2xl font-display font-bold text-warm-900"><%= nd.net_carbs %>g</span><br><span class="text-xs text-warm-500">Net Carbs</span></div>
+            <div><span class="text-2xl font-display font-bold text-warm-900"><%= nd.fiber %>g</span><br><span class="text-xs text-warm-500">Fiber</span></div>
+          </div>
         </div>
       </div>
     <% end %>

--- a/test/controllers/accounts/dietary_profiles_controller_test.rb
+++ b/test/controllers/accounts/dietary_profiles_controller_test.rb
@@ -22,11 +22,11 @@ class Accounts::DietaryProfilesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "h1", "Dietary Profiles"
     # Active profiles should appear
-    assert_select "td", "Dad"
-    assert_select "td", "Mom"
-    assert_select "td", "Timmy"
+    assert_select "h3", "Dad"
+    assert_select "h3", "Mom"
+    assert_select "h3", "Timmy"
     # Inactive should not
-    assert_select "td", text: "Grandpa", count: 0
+    assert_select "h3", text: "Grandpa", count: 0
   end
 
   test "should get new dietary profile form" do

--- a/test/helpers/nutrition_helper_test.rb
+++ b/test/helpers/nutrition_helper_test.rb
@@ -1,0 +1,136 @@
+require "test_helper"
+
+class NutritionHelperTest < ActionView::TestCase
+  include NutritionHelper
+
+  # === macro_donut_chart ===
+
+  test "macro_donut_chart renders conic-gradient with correct percentages" do
+    html = macro_donut_chart(fat_g: 70, protein_g: 25, carbs_g: 5)
+    assert_match(/conic-gradient/, html)
+    assert_match(/macro-donut/, html)
+  end
+
+  test "macro_donut_chart renders legend items" do
+    html = macro_donut_chart(fat_g: 70, protein_g: 25, carbs_g: 5)
+    assert_match(/Fat/, html)
+    assert_match(/Protein/, html)
+    assert_match(/Carbs/, html)
+  end
+
+  test "macro_donut_chart handles zero values" do
+    html = macro_donut_chart(fat_g: 0, protein_g: 0, carbs_g: 0)
+    assert_no_match(/conic-gradient/, html)
+    assert_match(/bg-warm-200/, html)
+  end
+
+  test "macro_donut_chart accepts custom size" do
+    html = macro_donut_chart(fat_g: 10, protein_g: 10, carbs_g: 10, size: 120)
+    assert_match(/width: 120px/, html)
+    assert_match(/height: 120px/, html)
+  end
+
+  test "macro_donut_chart handles nil values" do
+    html = macro_donut_chart(fat_g: nil, protein_g: nil, carbs_g: nil)
+    assert_no_match(/conic-gradient/, html)
+  end
+
+  # === mini_donut_chart ===
+
+  test "mini_donut_chart renders at 48px" do
+    html = mini_donut_chart(fat_g: 70, protein_g: 25, carbs_g: 5)
+    assert_match(/width: 48px/, html)
+  end
+
+  # === macro_progress_bar ===
+
+  test "macro_progress_bar renders bar with correct width" do
+    html = macro_progress_bar(actual: 50, target: 100, label: "Fat", macro_key: :fat)
+    assert_match(/width: 50%/, html)
+    assert_match(/Fat/, html)
+  end
+
+  test "macro_progress_bar caps at 100%" do
+    html = macro_progress_bar(actual: 150, target: 100, label: "Fat", macro_key: :fat)
+    assert_match(/width: 100%/, html)
+  end
+
+  test "macro_progress_bar shows green when within 10% of target" do
+    html = macro_progress_bar(actual: 95, target: 100, label: "Fat", macro_key: :fat)
+    assert_match(/bg-green-500/, html)
+  end
+
+  test "macro_progress_bar shows amber when within 25% of target" do
+    html = macro_progress_bar(actual: 80, target: 100, label: "Fat", macro_key: :fat)
+    assert_match(/bg-amber-500/, html)
+  end
+
+  test "macro_progress_bar shows red when outside range" do
+    html = macro_progress_bar(actual: 30, target: 100, label: "Fat", macro_key: :fat)
+    assert_match(/bg-red-400/, html)
+  end
+
+  test "macro_progress_bar handles nil target" do
+    html = macro_progress_bar(actual: 50, target: nil, label: "Fat", macro_key: :fat)
+    assert_match(/width: 0%/, html)
+    assert_match(/50g/, html)
+  end
+
+  test "macro_progress_bar handles zero target" do
+    html = macro_progress_bar(actual: 50, target: 0, label: "Fat", macro_key: :fat)
+    assert_match(/width: 0%/, html)
+  end
+
+  test "macro_progress_bar displays actual/target values" do
+    html = macro_progress_bar(actual: 65.3, target: 80.0, label: "Fat", macro_key: :fat)
+    assert_match(/65.3g/, html)
+    assert_match(/80.0g/, html)
+  end
+
+  test "macro_progress_bar supports custom unit" do
+    html = macro_progress_bar(actual: 1500, target: 2000, label: "Cal", macro_key: nil, unit: "")
+    assert_match(/1500/, html)
+    assert_match(/2000/, html)
+  end
+
+  # === diet_compatibility_badge ===
+
+  test "diet_compatibility_badge returns keto badge for low carb ratio" do
+    nd = RecipeNutritionData.new(calories: 500, fat: 40, protein: 30, carbs: 5, fiber: 2, net_carbs: 3)
+    badge = diet_compatibility_badge(nd)
+    assert_match(/Keto/, badge)
+  end
+
+  test "diet_compatibility_badge returns low-carb badge for moderate carb ratio" do
+    nd = RecipeNutritionData.new(calories: 500, fat: 30, protein: 30, carbs: 20, fiber: 5, net_carbs: 15)
+    badge = diet_compatibility_badge(nd)
+    assert_match(/Low-Carb/, badge)
+  end
+
+  test "diet_compatibility_badge returns high-protein badge" do
+    nd = RecipeNutritionData.new(calories: 400, fat: 10, protein: 40, carbs: 10, fiber: 2, net_carbs: 8)
+    badge = diet_compatibility_badge(nd)
+    assert_match(/High-Protein/, badge)
+  end
+
+  test "diet_compatibility_badge returns nil for standard macros" do
+    nd = RecipeNutritionData.new(calories: 500, fat: 15, protein: 20, carbs: 60, fiber: 5, net_carbs: 55)
+    assert_nil diet_compatibility_badge(nd)
+  end
+
+  test "diet_compatibility_badge returns nil for nil nutrition data" do
+    assert_nil diet_compatibility_badge(nil)
+  end
+
+  test "diet_compatibility_badge returns nil for zero calories" do
+    nd = RecipeNutritionData.new(calories: 0, fat: 0, protein: 0, carbs: 0)
+    assert_nil diet_compatibility_badge(nd)
+  end
+
+  test "diet_compatibility_badge can return multiple badges" do
+    nd = RecipeNutritionData.new(calories: 400, fat: 30, protein: 35, carbs: 3, fiber: 1, net_carbs: 2)
+    badge = diet_compatibility_badge(nd)
+    assert_match(/Keto/, badge)
+    assert_match(/High-Protein/, badge)
+  end
+end


### PR DESCRIPTION
## Summary

- CSS-only donut charts display fat/protein/carb ratios on recipe detail pages and dietary profile cards
- Color-coded progress bars replace text-based macro totals on meal plan day cards
- Diet compatibility badges (Keto, Low-Carb, High-Protein) appear on qualifying recipes

## Changes

- **New**: `app/helpers/nutrition_helper.rb` — `macro_donut_chart`, `macro_progress_bar`, `diet_compatibility_badge`, `mini_donut_chart` helpers
- **Updated**: `app/assets/tailwind/application.css` — `.macro-donut` mask class for ring effect
- **Updated**: `app/views/accounts/recipes/show.html.erb` — donut chart + diet badges in nutrition section
- **Updated**: `app/views/accounts/meal_plans/_day_card.html.erb` — progress bars for daily macros per participant
- **Updated**: `app/views/accounts/dietary_profiles/index.html.erb` — card layout with mini donut charts and macro targets
- **New**: `test/helpers/nutrition_helper_test.rb` — 20 tests covering all helper methods and edge cases

## Testing

- View any recipe with nutrition data to see the donut chart and diet badges
- View a meal plan with participants to see progress bars on day cards
- View dietary profiles index to see mini donut charts per profile
- All 617 tests pass, Rubocop clean, Brakeman clean

Closes #36