### PR TITLE
Add URL-based recipe import with JSON-LD and AI extraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,21 @@ Controllers under `app/controllers/accounts/api/v1/` inherit from `ActionControl
 
 **Subclassing pattern:** Implement `#execute(**args)` returning a Hash. Call `update_progress(n)` for incremental updates. Error handling and status transitions are automatic.
 
+### Recipe Import Pipeline
+
+URL-based recipe import lives in `app/services/recipe_import/`. The pipeline:
+
+1. **`UrlFetcher`** — HTTP fetch with redirect following (max 5), timeouts, user-agent
+2. **`JsonLdParser`** — Primary extraction: parses `<script type="application/ld+json">` for schema.org Recipe data via Nokogiri. Handles `@graph` arrays, ISO 8601 durations, HowToStep objects.
+3. **`AiExtractor`** — Fallback: sends stripped page text to Claude via `Ai::Client.chat_with_tools` with an `extract_recipe` tool definition. Truncates to 12K chars.
+4. **`UrlImporter`** — Orchestrator: fetch → try JSON-LD → try AI → raise `ImportError`. Exposes `method_used` (`:json_ld` or `:ai`).
+
+**Job:** `RecipeImportJob < AiBaseJob` runs the pipeline asynchronously, storing results in `AiTaskStatus.result`.
+
+**Controller flow:** `import_url` (form) → `start_import` (creates task, enqueues job) → `import_status` (polls with reload) → `import_review` (pre-fills recipe form from extracted data).
+
+**Testing pattern:** `UrlImporter` exposes a `fetch_html` private method that the test subclass (`TestableImporter`) overrides to return fixture HTML. `AiExtractor` accepts an `ai_client:` kwarg for injecting a fake client.
+
 ### Design System
 
 Defined in `app/assets/tailwind/application.css` using Tailwind v4 `@theme` block.

--- a/app/controllers/accounts/recipes_controller.rb
+++ b/app/controllers/accounts/recipes_controller.rb
@@ -102,6 +102,59 @@ class Accounts::RecipesController < ApplicationController
     end
   end
 
+  def import_url
+    @url = params[:url]
+  end
+
+  def start_import
+    url = params[:url].to_s.strip
+    if url.blank?
+      redirect_to import_url_recipes_path, alert: "Please enter a URL."
+      return
+    end
+
+    task = Current.account.ai_task_statuses.create!(task_type: "recipe_import")
+    RecipeImportJob.perform_later(task.id, url: url)
+
+    redirect_to import_status_recipes_path(task_id: task.id)
+  end
+
+  def import_status
+    @task = Current.account.ai_task_statuses.find(params[:task_id])
+
+    if @task.completed?
+      redirect_to import_review_recipes_path(task_id: @task.id)
+    elsif @task.failed?
+      redirect_to import_url_recipes_path, alert: "Import failed: #{@task.error_message}"
+    end
+  end
+
+  def import_review
+    @task = Current.account.ai_task_statuses.find(params[:task_id])
+    redirect_to import_url_recipes_path, alert: "Import is not yet complete." unless @task.completed?
+
+    result = @task.result.deep_symbolize_keys
+    @recipe = Current.account.recipes.build(
+      title: result[:title],
+      description: result[:description],
+      servings: result[:servings],
+      prep_time: result[:prep_time],
+      cook_time: result[:cook_time],
+      source: result[:source]
+    )
+
+    build_ingredients_from_import(result[:ingredients] || [])
+    build_instructions_from_import(result[:instructions] || [])
+    build_nutrition_from_import(result[:nutrition])
+
+    @recipe.ingredients.build if @recipe.ingredients.empty?
+    @recipe.instructions.build if @recipe.instructions.empty?
+    @recipe.build_nutrition_data unless @recipe.nutrition_data
+
+    set_unit_options
+    render :new
+  end
+
   def search_usda
     query = params[:query].to_s.strip
     if query.present?
@@ -150,6 +203,51 @@ class Accounts::RecipesController < ApplicationController
   def apply_calculated_nutrition(result)
     nutrition = @recipe.nutrition_data || @recipe.build_nutrition_data
     nutrition.update!(result.nutrition_data)
+  end
+
+  def build_ingredients_from_import(ingredients)
+    ingredients.each_with_index do |text, index|
+      parsed = parse_ingredient_text(text.to_s)
+      @recipe.ingredients.build(
+        name: parsed[:name],
+        quantity: parsed[:quantity],
+        unit: parsed[:unit],
+        display_order: index
+      )
+    end
+  end
+
+  def build_instructions_from_import(instructions)
+    instructions.each do |instr|
+      instr = instr.is_a?(Hash) ? instr.deep_symbolize_keys : { step_number: 1, instruction: instr.to_s }
+      @recipe.instructions.build(
+        step_number: instr[:step_number],
+        instruction: instr[:instruction]
+      )
+    end
+  end
+
+  def build_nutrition_from_import(nutrition)
+    return unless nutrition.is_a?(Hash)
+    nutrition = nutrition.deep_symbolize_keys
+    @recipe.build_nutrition_data(
+      calories: nutrition[:calories],
+      fat: nutrition[:fat],
+      protein: nutrition[:protein],
+      carbs: nutrition[:carbs],
+      fiber: nutrition[:fiber],
+      sodium: nutrition[:sodium]
+    )
+  end
+
+  def parse_ingredient_text(text)
+    # Match patterns like "2 cups almond flour" or "1/2 tsp salt"
+    match = text.match(/\A([\d\s\/½¼¾⅓⅔⅛.]+)?\s*(#{Ingredient::UNITS_PATTERN})?\s*(.+)\z/i)
+    if match
+      { quantity: match[1]&.strip, unit: match[2]&.strip&.downcase, name: match[3]&.strip }
+    else
+      { quantity: nil, unit: nil, name: text.strip }
+    end
   end
 
   def recipe_params

--- a/app/jobs/recipe_import_job.rb
+++ b/app/jobs/recipe_import_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class RecipeImportJob < AiBaseJob
+  private
+
+  def execute(url:)
+    update_progress(10)
+    importer = RecipeImport::UrlImporter.new(url)
+
+    update_progress(30)
+    recipe_data = importer.import
+
+    update_progress(90)
+    recipe_data.merge(method_used: importer.method_used.to_s)
+  end
+end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -4,6 +4,8 @@ class Ingredient < ApplicationRecord
   STANDARD_UNITS = %w[cups tbsp tsp oz lb fl\ oz quart gallon pint].freeze
   METRIC_UNITS = %w[ml l g kg].freeze
   UNIVERSAL_UNITS = %w[pinch dash whole slice clove piece].freeze
+  ALL_UNITS = (STANDARD_UNITS + METRIC_UNITS + UNIVERSAL_UNITS).freeze
+  UNITS_PATTERN = Regexp.union(ALL_UNITS).freeze
 
   def self.grouped_unit_options(unit_system = "standard")
     if unit_system == "metric"

--- a/app/services/recipe_import/ai_extractor.rb
+++ b/app/services/recipe_import/ai_extractor.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module RecipeImport
+  class AiExtractor
+    SYSTEM_PROMPT = <<~PROMPT
+      You are a recipe extraction assistant. Given the text content of a web page,
+      extract the recipe information and return it using the provided tool.
+      If the page does not contain a recipe, return empty values.
+      For ingredients, include the full text as written (e.g. "2 cups almond flour").
+      For instructions, extract each step as a separate item.
+    PROMPT
+
+    RECIPE_TOOL = {
+      name: "extract_recipe",
+      description: "Extract structured recipe data from page content",
+      input_schema: {
+        type: "object",
+        properties: {
+          title: { type: "string", description: "Recipe title" },
+          description: { type: "string", description: "Brief recipe description" },
+          servings: { type: "integer", description: "Number of servings" },
+          prep_time: { type: "integer", description: "Prep time in minutes" },
+          cook_time: { type: "integer", description: "Cook time in minutes" },
+          ingredients: {
+            type: "array",
+            items: { type: "string" },
+            description: "List of ingredients with quantities"
+          },
+          instructions: {
+            type: "array",
+            items: { type: "string" },
+            description: "Ordered list of cooking steps"
+          },
+          calories: { type: "number", description: "Calories per serving" },
+          fat: { type: "number", description: "Fat grams per serving" },
+          protein: { type: "number", description: "Protein grams per serving" },
+          carbs: { type: "number", description: "Carbs grams per serving" },
+          fiber: { type: "number", description: "Fiber grams per serving" }
+        },
+        required: [ "title", "ingredients", "instructions" ]
+      }
+    }.freeze
+
+    def initialize(page_text, ai_client: nil)
+      @page_text = page_text
+      @ai_client = ai_client || Ai::Client.new
+    end
+
+    def extract
+      # Truncate page text to avoid token limits
+      truncated = @page_text[0, 12_000]
+
+      result = @ai_client.chat_with_tools(
+        messages: [ { role: "user", content: "Extract the recipe from this page:\n\n#{truncated}" } ],
+        tools: [ RECIPE_TOOL ],
+        system: SYSTEM_PROMPT,
+        max_tokens: 4096
+      )
+
+      normalize(result[:input])
+    end
+
+    private
+
+    def normalize(input)
+      instructions = (input["instructions"] || []).map.with_index(1) do |text, i|
+        { step_number: i, instruction: text }
+      end
+
+      nutrition = {
+        calories: input["calories"],
+        fat: input["fat"],
+        protein: input["protein"],
+        carbs: input["carbs"],
+        fiber: input["fiber"]
+      }.compact.presence
+
+      {
+        title: input["title"],
+        description: input["description"],
+        servings: input["servings"],
+        prep_time: input["prep_time"],
+        cook_time: input["cook_time"],
+        ingredients: input["ingredients"] || [],
+        instructions: instructions,
+        nutrition: nutrition
+      }.compact
+    end
+  end
+end

--- a/app/services/recipe_import/json_ld_parser.rb
+++ b/app/services/recipe_import/json_ld_parser.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require "nokogiri"
+require "json"
+
+module RecipeImport
+  class JsonLdParser
+    def initialize(html)
+      @html = html
+    end
+
+    # Returns a normalized recipe hash or nil if no Recipe JSON-LD found
+    def parse
+      recipe_data = extract_recipe_json_ld
+      return nil unless recipe_data
+
+      normalize(recipe_data)
+    end
+
+    private
+
+    def extract_recipe_json_ld
+      doc = Nokogiri::HTML(@html)
+      doc.css('script[type="application/ld+json"]').each do |script|
+        data = safe_parse_json(script.text)
+        next unless data
+
+        recipe = find_recipe(data)
+        return recipe if recipe
+      end
+
+      nil
+    end
+
+    def safe_parse_json(text)
+      JSON.parse(text)
+    rescue JSON::ParserError
+      nil
+    end
+
+    def find_recipe(data)
+      case data
+      when Hash
+        return data if recipe_type?(data)
+        # Check @graph arrays
+        if data["@graph"].is_a?(Array)
+          data["@graph"].each do |item|
+            return item if recipe_type?(item)
+          end
+        end
+      when Array
+        data.each do |item|
+          result = find_recipe(item)
+          return result if result
+        end
+      end
+
+      nil
+    end
+
+    def recipe_type?(item)
+      return false unless item.is_a?(Hash)
+      type = item["@type"]
+      type == "Recipe" || (type.is_a?(Array) && type.include?("Recipe"))
+    end
+
+    def normalize(data)
+      {
+        title: data["name"].to_s.strip,
+        description: extract_text(data["description"]),
+        servings: parse_yield(data["recipeYield"]),
+        prep_time: parse_duration(data["prepTime"]),
+        cook_time: parse_duration(data["cookTime"]),
+        ingredients: parse_ingredients(data["recipeIngredient"]),
+        instructions: parse_instructions(data["recipeInstructions"]),
+        nutrition: parse_nutrition(data["nutrition"]),
+        source: data["url"] || data["mainEntityOfPage"]
+      }.compact
+    end
+
+    def extract_text(value)
+      case value
+      when String then value.strip
+      when Array then value.map(&:to_s).join(" ").strip
+      end
+    end
+
+    def parse_yield(value)
+      case value
+      when Integer then value
+      when String then value[/\d+/]&.to_i
+      when Array then value.first.to_s[/\d+/]&.to_i
+      end
+    end
+
+    def parse_duration(iso8601)
+      return nil unless iso8601.is_a?(String)
+      match = iso8601.match(/PT(?:(\d+)H)?(?:(\d+)M)?/)
+      return nil unless match
+      hours = (match[1] || 0).to_i
+      minutes = (match[2] || 0).to_i
+      hours * 60 + minutes
+    end
+
+    def parse_ingredients(list)
+      return [] unless list.is_a?(Array)
+      list.filter_map do |item|
+        text = item.is_a?(String) ? item : item.to_s
+        text.strip.presence
+      end
+    end
+
+    def parse_instructions(list)
+      return [] unless list.is_a?(Array)
+      list.filter_map.with_index(1) do |item, index|
+        text = case item
+        when String then item
+        when Hash then item["text"]
+        end
+        next unless text.present?
+        { step_number: index, instruction: text.strip }
+      end
+    end
+
+    def parse_nutrition(data)
+      return nil unless data.is_a?(Hash)
+      {
+        calories: extract_number(data["calories"]),
+        fat: extract_number(data["fatContent"]),
+        protein: extract_number(data["proteinContent"]),
+        carbs: extract_number(data["carbohydrateContent"]),
+        fiber: extract_number(data["fiberContent"]),
+        sodium: extract_number(data["sodiumContent"])
+      }.compact.presence
+    end
+
+    def extract_number(value)
+      return nil unless value
+      value.to_s[/[\d.]+/]&.to_f&.round(1)
+    end
+  end
+end

--- a/app/services/recipe_import/url_fetcher.rb
+++ b/app/services/recipe_import/url_fetcher.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "net/http"
+
+module RecipeImport
+  class UrlFetcher
+    class FetchError < StandardError; end
+
+    MAX_REDIRECTS = 5
+    TIMEOUT = 15
+    USER_AGENT = "MealSzn/1.0 RecipeImporter"
+
+    def initialize(url)
+      @url = url
+    end
+
+    def fetch
+      uri = validated_uri
+      follow_redirects(uri)
+    rescue URI::InvalidURIError => e
+      raise FetchError, "Invalid URL: #{e.message}"
+    rescue Net::OpenTimeout, Net::ReadTimeout
+      raise FetchError, "Request timed out"
+    rescue SocketError, Errno::ECONNREFUSED => e
+      raise FetchError, "Could not connect: #{e.message}"
+    rescue OpenSSL::SSL::SSLError => e
+      raise FetchError, "SSL error: #{e.message}"
+    end
+
+    private
+
+    def validated_uri
+      uri = URI.parse(@url)
+      raise URI::InvalidURIError, "URL must use http or https" unless %w[http https].include?(uri.scheme)
+      uri
+    end
+
+    def follow_redirects(uri, limit = MAX_REDIRECTS)
+      raise FetchError, "Too many redirects" if limit == 0
+
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == "https"
+      http.open_timeout = TIMEOUT
+      http.read_timeout = TIMEOUT
+
+      request = Net::HTTP::Get.new(uri)
+      request["User-Agent"] = USER_AGENT
+      request["Accept"] = "text/html"
+
+      response = http.request(request)
+
+      case response
+      when Net::HTTPSuccess
+        response.body.force_encoding("UTF-8")
+      when Net::HTTPRedirection
+        location = response["location"]
+        new_uri = URI.parse(location)
+        new_uri = URI.join(uri, location) unless new_uri.host
+        follow_redirects(new_uri, limit - 1)
+      else
+        raise FetchError, "HTTP #{response.code}: #{response.message}"
+      end
+    end
+  end
+end

--- a/app/services/recipe_import/url_importer.rb
+++ b/app/services/recipe_import/url_importer.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module RecipeImport
+  class UrlImporter
+    class ImportError < StandardError; end
+
+    attr_reader :url, :method_used
+
+    def initialize(url, ai_client: nil)
+      @url = url
+      @ai_client = ai_client
+      @method_used = nil
+    end
+
+    def import
+      html = fetch_html
+      recipe_data = try_json_ld(html) || try_ai_extraction(html)
+
+      raise ImportError, "Could not extract recipe data from this URL" unless recipe_data
+      raise ImportError, "No recipe title found" if recipe_data[:title].blank?
+
+      recipe_data[:source] = @url
+      recipe_data
+    rescue UrlFetcher::FetchError => e
+      raise ImportError, "Failed to fetch URL: #{e.message}"
+    end
+
+    private
+
+    def fetch_html
+      UrlFetcher.new(@url).fetch
+    end
+
+    def try_json_ld(html)
+      result = JsonLdParser.new(html).parse
+      if result && result[:title].present?
+        @method_used = :json_ld
+        result
+      end
+    end
+
+    def try_ai_extraction(html)
+      # Strip HTML to plain text for AI
+      text = extract_text(html)
+      return nil if text.blank?
+
+      result = AiExtractor.new(text, ai_client: @ai_client).extract
+      if result && result[:title].present?
+        @method_used = :ai
+        result
+      end
+    rescue Ai::Client::Error
+      nil
+    end
+
+    def extract_text(html)
+      doc = Nokogiri::HTML(html)
+      doc.css("script, style, nav, header, footer, aside").remove
+      doc.text.gsub(/\s+/, " ").strip[0, 15_000]
+    end
+  end
+end

--- a/app/views/accounts/recipes/import_status.html.erb
+++ b/app/views/accounts/recipes/import_status.html.erb
@@ -1,0 +1,30 @@
+<div class="max-w-2xl mx-auto text-center">
+  <h1 class="font-display font-bold text-3xl text-warm-900 mb-4">Importing Recipe...</h1>
+
+  <div class="card-warm p-8 space-y-6">
+    <div class="flex justify-center">
+      <svg class="animate-spin h-12 w-12 text-primary-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+      </svg>
+    </div>
+
+    <p class="text-warm-600 text-lg">
+      We're extracting the recipe from the page. This usually takes a few seconds.
+    </p>
+
+    <div class="w-full bg-warm-200 rounded-full h-2">
+      <div class="bg-primary-600 h-2 rounded-full transition-all duration-500" style="width: <%= @task.progress_percentage %>%"></div>
+    </div>
+
+    <p class="text-sm text-warm-500"><%= @task.progress_percentage %>% complete</p>
+  </div>
+</div>
+
+<%= tag.meta name: "turbo-refresh-scroll", content: "preserve" %>
+<script>
+  // Poll for completion
+  setTimeout(function() {
+    window.location.reload();
+  }, 2000);
+</script>

--- a/app/views/accounts/recipes/import_url.html.erb
+++ b/app/views/accounts/recipes/import_url.html.erb
@@ -1,0 +1,24 @@
+<div class="max-w-2xl mx-auto">
+  <h1 class="font-display font-bold text-3xl text-warm-900 mb-2">Import Recipe from URL</h1>
+  <p class="text-warm-600 mb-8">Paste a link to a recipe page and we'll extract the details for you to review.</p>
+
+  <div class="card-warm p-8">
+    <%= form_with url: start_import_recipes_path, method: :post, class: "space-y-6" do |f| %>
+      <div>
+        <%= f.label :url, "Recipe URL", class: "block text-sm font-medium text-warm-700 mb-1" %>
+        <%= f.url_field :url,
+            value: @url,
+            placeholder: "https://example.com/recipe/keto-pancakes",
+            class: "w-full px-4 py-3 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-lg",
+            required: true,
+            autofocus: true %>
+        <p class="mt-2 text-sm text-warm-500">Works with most recipe sites — AllRecipes, Food Network, and more.</p>
+      </div>
+
+      <div class="flex items-center gap-4">
+        <%= f.submit "Import Recipe", class: "px-6 py-3 bg-primary-600 text-white font-semibold rounded-lg hover:bg-primary-700 transition-colors cursor-pointer" %>
+        <%= link_to "Cancel", recipes_path, class: "text-warm-600 hover:text-warm-800" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,10 @@ Rails.application.routes.draw do
       end
       collection do
         get :search_usda
+        get :import_url
+        post :start_import
+        get :import_status
+        get :import_review
       end
     end
 

--- a/test/controllers/accounts/recipes_controller_test.rb
+++ b/test/controllers/accounts/recipes_controller_test.rb
@@ -323,4 +323,84 @@ class Accounts::RecipesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "select[name='recipe[nutrition_mode]']"
   end
+
+  # --- Import URL ---
+
+  test "import_url shows URL input form" do
+    sign_in_as(@session)
+    get "#{account_path_prefix}/recipes/import_url"
+    assert_response :success
+    assert_select "h1", "Import Recipe from URL"
+    assert_select "input[type='url']"
+  end
+
+  test "start_import redirects to import_url when URL is blank" do
+    sign_in_as(@session)
+    post "#{account_path_prefix}/recipes/start_import", params: { url: "" }
+    assert_redirected_to import_url_recipes_path
+    assert_equal "Please enter a URL.", flash[:alert]
+  end
+
+  test "start_import creates task and redirects to status" do
+    sign_in_as(@session)
+
+    assert_difference "AiTaskStatus.count" do
+      post "#{account_path_prefix}/recipes/start_import", params: { url: "https://example.com/recipe" }
+    end
+
+    task = AiTaskStatus.order(created_at: :desc).first
+    assert_equal "recipe_import", task.task_type
+    assert_redirected_to import_status_recipes_path(task_id: task.id)
+  end
+
+  test "import_status shows spinner for pending task" do
+    sign_in_as(@session)
+    task = @account.ai_task_statuses.create!(task_type: "recipe_import")
+
+    get "#{account_path_prefix}/recipes/import_status", params: { task_id: task.id }
+    assert_response :success
+    assert_select "h1", "Importing Recipe..."
+  end
+
+  test "import_status redirects to review when task completed" do
+    sign_in_as(@session)
+    task = @account.ai_task_statuses.create!(task_type: "recipe_import")
+    task.mark_processing!
+    task.mark_completed!(result: { title: "Test" })
+
+    get "#{account_path_prefix}/recipes/import_status", params: { task_id: task.id }
+    assert_redirected_to import_review_recipes_path(task_id: task.id)
+  end
+
+  test "import_status redirects to import_url when task failed" do
+    sign_in_as(@session)
+    task = @account.ai_task_statuses.create!(task_type: "recipe_import")
+    task.mark_processing!
+    task.mark_failed!(error_message: "Something went wrong")
+
+    get "#{account_path_prefix}/recipes/import_status", params: { task_id: task.id }
+    assert_redirected_to import_url_recipes_path
+    assert_match(/Something went wrong/, flash[:alert])
+  end
+
+  test "import_review renders new recipe form with prefilled data" do
+    sign_in_as(@session)
+    task = @account.ai_task_statuses.create!(task_type: "recipe_import")
+    task.mark_processing!
+    task.mark_completed!(result: {
+      title: "Imported Recipe",
+      description: "A great recipe",
+      servings: 4,
+      prep_time: 10,
+      cook_time: 20,
+      source: "https://example.com/recipe",
+      ingredients: [ "2 cups almond flour", "3 eggs" ],
+      instructions: [ { step_number: 1, instruction: "Mix" }, { step_number: 2, instruction: "Bake" } ],
+      nutrition: { calories: 300, fat: 20, protein: 15, carbs: 5 }
+    })
+
+    get "#{account_path_prefix}/recipes/import_review", params: { task_id: task.id }
+    assert_response :success
+    assert_select "h1", "New Recipe"
+  end
 end

--- a/test/fixtures/files/recipe_with_jsonld.html
+++ b/test/fixtures/files/recipe_with_jsonld.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Keto Garlic Butter Salmon - Test Recipe Site</title>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Recipe",
+    "name": "Keto Garlic Butter Salmon",
+    "description": "A simple and delicious keto salmon recipe with garlic butter sauce.",
+    "recipeYield": "4 servings",
+    "prepTime": "PT10M",
+    "cookTime": "PT15M",
+    "recipeIngredient": [
+      "4 salmon fillets (6 oz each)",
+      "3 tablespoons butter",
+      "4 cloves garlic, minced",
+      "1 tablespoon lemon juice",
+      "1 teaspoon dried dill",
+      "Salt and pepper to taste"
+    ],
+    "recipeInstructions": [
+      {
+        "@type": "HowToStep",
+        "text": "Pat salmon fillets dry and season with salt and pepper."
+      },
+      {
+        "@type": "HowToStep",
+        "text": "Heat butter in a large skillet over medium-high heat."
+      },
+      {
+        "@type": "HowToStep",
+        "text": "Place salmon skin-side up and cook for 4 minutes until golden."
+      },
+      {
+        "@type": "HowToStep",
+        "text": "Flip salmon, add garlic, and cook 4 more minutes."
+      },
+      {
+        "@type": "HowToStep",
+        "text": "Drizzle with lemon juice and sprinkle dill. Serve immediately."
+      }
+    ],
+    "nutrition": {
+      "@type": "NutritionInformation",
+      "calories": "380 calories",
+      "fatContent": "24g",
+      "proteinContent": "38g",
+      "carbohydrateContent": "2g",
+      "fiberContent": "0g",
+      "sodiumContent": "280mg"
+    },
+    "url": "https://example.com/keto-garlic-butter-salmon"
+  }
+  </script>
+</head>
+<body>
+  <h1>Keto Garlic Butter Salmon</h1>
+  <p>A simple and delicious keto salmon recipe.</p>
+</body>
+</html>

--- a/test/fixtures/files/recipe_without_jsonld.html
+++ b/test/fixtures/files/recipe_without_jsonld.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Best Keto Pancakes - My Recipe Blog</title>
+</head>
+<body>
+  <nav>Home | Recipes | About</nav>
+  <article>
+    <h1>Best Keto Pancakes</h1>
+    <p>These fluffy keto pancakes are perfect for a low-carb breakfast.</p>
+
+    <div class="recipe-meta">
+      <span>Servings: 8 pancakes</span>
+      <span>Prep: 5 minutes</span>
+      <span>Cook: 10 minutes</span>
+    </div>
+
+    <h2>Ingredients</h2>
+    <ul>
+      <li>2 oz cream cheese, softened</li>
+      <li>2 large eggs</li>
+      <li>1 tsp vanilla extract</li>
+      <li>2 tbsp almond flour</li>
+      <li>1 packet stevia</li>
+      <li>1/2 tsp cinnamon</li>
+      <li>Butter for cooking</li>
+    </ul>
+
+    <h2>Instructions</h2>
+    <ol>
+      <li>Blend cream cheese, eggs, vanilla, almond flour, stevia, and cinnamon until smooth.</li>
+      <li>Heat a non-stick pan over medium heat and add butter.</li>
+      <li>Pour small circles of batter and cook 2 minutes per side.</li>
+      <li>Serve with sugar-free syrup or berries.</li>
+    </ol>
+
+    <h2>Nutrition per serving</h2>
+    <p>Calories: 80, Fat: 6g, Protein: 4g, Carbs: 1g</p>
+  </article>
+  <footer>Copyright 2024</footer>
+</body>
+</html>

--- a/test/jobs/recipe_import_job_test.rb
+++ b/test/jobs/recipe_import_job_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RecipeImportJobTest < ActiveSupport::TestCase
+  setup do
+    @account = accounts(:one)
+    @task = @account.ai_task_statuses.create!(task_type: "recipe_import")
+  end
+
+  test "job is enqueued on ai queue" do
+    assert_equal "ai", RecipeImportJob.new.queue_name
+  end
+
+  test "job inherits from AiBaseJob" do
+    assert RecipeImportJob < AiBaseJob
+  end
+end

--- a/test/services/recipe_import/ai_extractor_test.rb
+++ b/test/services/recipe_import/ai_extractor_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RecipeImport::AiExtractorTest < ActiveSupport::TestCase
+  # Fake AI client that returns a predetermined tool_use result
+  class FakeAiClient
+    attr_reader :last_call
+
+    def initialize(tool_input)
+      @tool_input = tool_input
+    end
+
+    def chat_with_tools(messages:, tools:, system: nil, max_tokens: 4096)
+      @last_call = { messages: messages, tools: tools, system: system, max_tokens: max_tokens }
+      { name: "extract_recipe", input: @tool_input }
+    end
+  end
+
+  test "extracts recipe data via AI client" do
+    fake_client = FakeAiClient.new({
+      "title" => "Keto Pancakes",
+      "description" => "Fluffy low-carb pancakes",
+      "servings" => 4,
+      "prep_time" => 5,
+      "cook_time" => 10,
+      "ingredients" => [ "2 oz cream cheese", "2 eggs", "1 tbsp almond flour" ],
+      "instructions" => [ "Mix ingredients", "Cook on medium heat", "Flip and serve" ],
+      "calories" => 120.0,
+      "fat" => 9.0,
+      "protein" => 6.0,
+      "carbs" => 2.0
+    })
+
+    extractor = RecipeImport::AiExtractor.new("Some page text about pancakes", ai_client: fake_client)
+    result = extractor.extract
+
+    assert_equal "Keto Pancakes", result[:title]
+    assert_equal "Fluffy low-carb pancakes", result[:description]
+    assert_equal 4, result[:servings]
+    assert_equal 3, result[:ingredients].length
+    assert_equal 3, result[:instructions].length
+    assert_equal 1, result[:instructions].first[:step_number]
+    assert_equal "Mix ingredients", result[:instructions].first[:instruction]
+    assert_equal 120.0, result[:nutrition][:calories]
+    assert_equal 9.0, result[:nutrition][:fat]
+  end
+
+  test "normalizes instructions with step numbers" do
+    fake_client = FakeAiClient.new({
+      "title" => "Test",
+      "ingredients" => [ "water" ],
+      "instructions" => [ "Step A", "Step B" ]
+    })
+
+    result = RecipeImport::AiExtractor.new("text", ai_client: fake_client).extract
+
+    assert_equal 1, result[:instructions][0][:step_number]
+    assert_equal 2, result[:instructions][1][:step_number]
+  end
+
+  test "handles missing nutrition gracefully" do
+    fake_client = FakeAiClient.new({
+      "title" => "Simple Recipe",
+      "ingredients" => [ "1 egg" ],
+      "instructions" => [ "Cook it" ]
+    })
+
+    result = RecipeImport::AiExtractor.new("text", ai_client: fake_client).extract
+
+    assert_nil result[:nutrition]
+  end
+
+  test "truncates long page text" do
+    long_text = "x" * 20_000
+    fake_client = FakeAiClient.new({
+      "title" => "Test",
+      "ingredients" => [ "water" ],
+      "instructions" => [ "boil" ]
+    })
+
+    RecipeImport::AiExtractor.new(long_text, ai_client: fake_client).extract
+
+    # The message content should contain truncated text
+    message_content = fake_client.last_call[:messages].first[:content]
+    assert message_content.length < 20_000
+  end
+
+  test "RECIPE_TOOL has required fields" do
+    tool = RecipeImport::AiExtractor::RECIPE_TOOL
+    assert_equal "extract_recipe", tool[:name]
+    assert_includes tool[:input_schema][:required], "title"
+    assert_includes tool[:input_schema][:required], "ingredients"
+    assert_includes tool[:input_schema][:required], "instructions"
+  end
+end

--- a/test/services/recipe_import/json_ld_parser_test.rb
+++ b/test/services/recipe_import/json_ld_parser_test.rb
@@ -96,4 +96,17 @@ class RecipeImport::JsonLdParserTest < ActiveSupport::TestCase
     assert_equal 2, result[:instructions].length
     assert_equal "Step one", result[:instructions].first[:instruction]
   end
+
+  test "handles invalid JSON gracefully" do
+    html = <<~HTML
+      <html><head>
+      <script type="application/ld+json">
+      {not valid json at all}
+      </script>
+      </head><body></body></html>
+    HTML
+
+    result = RecipeImport::JsonLdParser.new(html).parse
+    assert_nil result
+  end
 end

--- a/test/services/recipe_import/url_fetcher_test.rb
+++ b/test/services/recipe_import/url_fetcher_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "net/http"
+
+class RecipeImport::UrlFetcherTest < ActiveSupport::TestCase
+  test "raises FetchError for invalid scheme" do
+    assert_raises(RecipeImport::UrlFetcher::FetchError) do
+      RecipeImport::UrlFetcher.new("ftp://example.com/recipe").fetch
+    end
+  end
+
+  test "raises FetchError for non-URL string" do
+    assert_raises(RecipeImport::UrlFetcher::FetchError) do
+      RecipeImport::UrlFetcher.new("not a url").fetch
+    end
+  end
+
+  test "raises FetchError for blank URL" do
+    assert_raises(RecipeImport::UrlFetcher::FetchError) do
+      RecipeImport::UrlFetcher.new("").fetch
+    end
+  end
+
+  test "constants are properly set" do
+    assert_equal 5, RecipeImport::UrlFetcher::MAX_REDIRECTS
+    assert_equal 15, RecipeImport::UrlFetcher::TIMEOUT
+    assert_equal "MealSzn/1.0 RecipeImporter", RecipeImport::UrlFetcher::USER_AGENT
+  end
+end

--- a/test/services/recipe_import/url_importer_test.rb
+++ b/test/services/recipe_import/url_importer_test.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RecipeImport::UrlImporterTest < ActiveSupport::TestCase
+  # Testable subclass that overrides URL fetching with predetermined HTML
+  class TestableImporter < RecipeImport::UrlImporter
+    attr_accessor :stub_html, :stub_fetch_error
+
+    def initialize(url, stub_html: nil, stub_fetch_error: nil, ai_client: nil)
+      super(url, ai_client: ai_client)
+      @stub_html = stub_html
+      @stub_fetch_error = stub_fetch_error
+    end
+
+    private
+
+    # Override the fetch step to return stub HTML or raise
+    def fetch_html
+      raise RecipeImport::UrlFetcher::FetchError, @stub_fetch_error if @stub_fetch_error
+      @stub_html
+    end
+  end
+
+  def fixture_html(name)
+    File.read(Rails.root.join("test/fixtures/files/#{name}"))
+  end
+
+  test "imports recipe from page with JSON-LD" do
+    html = fixture_html("recipe_with_jsonld.html")
+    importer = TestableImporter.new("https://example.com/recipe", stub_html: html)
+    result = importer.import
+
+    assert_equal "Keto Garlic Butter Salmon", result[:title]
+    assert_equal :json_ld, importer.method_used
+    assert_equal "https://example.com/recipe", result[:source]
+  end
+
+  test "sets source to the import URL" do
+    html = fixture_html("recipe_with_jsonld.html")
+    importer = TestableImporter.new("https://mysite.com/my-recipe", stub_html: html)
+    result = importer.import
+    assert_equal "https://mysite.com/my-recipe", result[:source]
+  end
+
+  test "raises ImportError when fetch fails" do
+    importer = TestableImporter.new("https://example.com/404", stub_fetch_error: "Connection refused")
+
+    error = assert_raises(RecipeImport::UrlImporter::ImportError) do
+      importer.import
+    end
+    assert_match(/Failed to fetch URL/, error.message)
+  end
+
+  test "raises ImportError when no recipe data found" do
+    empty_html = "<html><body><p>Just a blog post with no recipe.</p></body></html>"
+
+    # Fake AI client that returns empty/blank result
+    fake_ai_client = Class.new {
+      def chat_with_tools(**args)
+        { name: "extract_recipe", input: { "title" => "", "ingredients" => [], "instructions" => [] } }
+      end
+    }.new
+
+    importer = TestableImporter.new("https://example.com/blog", stub_html: empty_html, ai_client: fake_ai_client)
+    error = assert_raises(RecipeImport::UrlImporter::ImportError) do
+      importer.import
+    end
+    assert_match(/Could not extract recipe data/, error.message)
+  end
+
+  test "falls back to AI when no JSON-LD present" do
+    html = fixture_html("recipe_without_jsonld.html")
+
+    fake_ai_client = Class.new {
+      def chat_with_tools(**args)
+        { name: "extract_recipe", input: {
+          "title" => "Best Keto Pancakes",
+          "ingredients" => [ "2 oz cream cheese", "2 eggs" ],
+          "instructions" => [ "Blend ingredients", "Cook" ]
+        } }
+      end
+    }.new
+
+    importer = TestableImporter.new("https://example.com/pancakes", stub_html: html, ai_client: fake_ai_client)
+    result = importer.import
+
+    assert_equal "Best Keto Pancakes", result[:title]
+    assert_equal :ai, importer.method_used
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a complete recipe import pipeline: fetch URL → extract via JSON-LD (primary) → AI fallback → async job with progress tracking → review & pre-fill recipe form
- Four service classes in `RecipeImport::` namespace: `UrlFetcher`, `JsonLdParser`, `AiExtractor`, `UrlImporter`
- `RecipeImportJob` extends `AiBaseJob` for async processing with progress updates

## Changes

- `app/services/recipe_import/` — 4 new service classes for the import pipeline
- `app/jobs/recipe_import_job.rb` — async job wrapping the import orchestrator
- `app/controllers/accounts/recipes_controller.rb` — 4 new actions: `import_url`, `start_import`, `import_status`, `import_review`
- `config/routes.rb` — collection routes for import workflow
- `app/views/accounts/recipes/` — `import_url.html.erb` (URL form), `import_status.html.erb` (progress spinner)
- `app/models/ingredient.rb` — `ALL_UNITS` and `UNITS_PATTERN` constants for ingredient text parsing
- `CLAUDE.md` — documented Recipe Import Pipeline architecture

## Testing

- 10 new unit tests for service classes (JSON-LD parser, AI extractor, URL importer, URL fetcher)
- 2 new job tests
- 7 new controller integration tests for import flow
- All 627 tests pass, 0 failures
- Rubocop: 0 offenses
- Brakeman: 0 warnings
- Bundle/importmap audit: clean

## Test plan

- [ ] Visit `/:account_id/recipes/import_url` and verify URL input form renders
- [ ] Submit a URL with JSON-LD recipe data and verify extraction works
- [ ] Submit a URL without JSON-LD and verify AI fallback triggers
- [ ] Verify import_status page shows progress spinner and polls
- [ ] Verify import_review pre-fills the recipe form with extracted data
- [ ] Verify blank URL submission shows error message

Closes #8