### PR TITLE
Implement photo-based recipe import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,11 +90,13 @@ URL-based recipe import lives in `app/services/recipe_import/`. The pipeline:
 3. **`AiExtractor`** — Fallback: sends stripped page text to Claude via `Ai::Client.chat_with_tools` with an `extract_recipe` tool definition. Truncates to 12K chars.
 4. **`UrlImporter`** — Orchestrator: fetch → try JSON-LD → try AI → raise `ImportError`. Exposes `method_used` (`:json_ld` or `:ai`).
 
-**Job:** `RecipeImportJob < AiBaseJob` runs the pipeline asynchronously, storing results in `AiTaskStatus.result`.
+**Photo import:** `PhotoExtractor` sends images (Active Storage blobs or raw base64 hashes) to Claude vision via `Ai::Client.chat_with_tools` with the same `extract_recipe` tool. Supports multi-image for multi-page recipes. Max 10MB per image, JPEG/PNG/GIF/WebP.
 
-**Controller flow:** `import_url` (form) → `start_import` (creates task, enqueues job) → `import_status` (polls with reload) → `import_review` (pre-fills recipe form from extracted data).
+**Jobs:** `RecipeImportJob < AiBaseJob` (URL pipeline), `RecipeImportPhotoJob < AiBaseJob` (photo pipeline). Both store results in `AiTaskStatus.result`.
 
-**Testing pattern:** `UrlImporter` exposes a `fetch_html` private method that the test subclass (`TestableImporter`) overrides to return fixture HTML. `AiExtractor` accepts an `ai_client:` kwarg for injecting a fake client.
+**Controller flow:** Two entry points — `import_url` (URL form) and `import_photo` (file upload form). Both flow through shared `import_status` (polls with reload) → `import_review` (pre-fills recipe form). Task types: `recipe_import` (URL) and `recipe_photo_import` (photo) — used to route failure redirects back to the correct form.
+
+**Testing pattern:** `UrlImporter` exposes a `fetch_html` private method that the test subclass (`TestableImporter`) overrides to return fixture HTML. `AiExtractor` and `PhotoExtractor` accept an `ai_client:` kwarg for injecting a fake client.
 
 ### Design System
 

--- a/app/controllers/accounts/recipes_controller.rb
+++ b/app/controllers/accounts/recipes_controller.rb
@@ -119,13 +119,38 @@ class Accounts::RecipesController < ApplicationController
     redirect_to import_status_recipes_path(task_id: task.id)
   end
 
+  def import_photo
+  end
+
+  def start_photo_import
+    photos = params[:photos]
+    if photos.blank?
+      redirect_to import_photo_recipes_path, alert: "Please select at least one photo."
+      return
+    end
+
+    blob_ids = photos.map do |photo|
+      ActiveStorage::Blob.create_and_upload!(
+        io: photo,
+        filename: photo.original_filename,
+        content_type: photo.content_type
+      ).id
+    end
+
+    task = Current.account.ai_task_statuses.create!(task_type: "recipe_photo_import")
+    RecipeImportPhotoJob.perform_later(task.id, blob_ids: blob_ids)
+
+    redirect_to import_status_recipes_path(task_id: task.id)
+  end
+
   def import_status
     @task = Current.account.ai_task_statuses.find(params[:task_id])
 
     if @task.completed?
       redirect_to import_review_recipes_path(task_id: @task.id)
     elsif @task.failed?
-      redirect_to import_url_recipes_path, alert: "Import failed: #{@task.error_message}"
+      failure_path = @task.task_type == "recipe_photo_import" ? import_photo_recipes_path : import_url_recipes_path
+      redirect_to failure_path, alert: "Import failed: #{@task.error_message}"
     end
   end
 

--- a/app/jobs/recipe_import_photo_job.rb
+++ b/app/jobs/recipe_import_photo_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class RecipeImportPhotoJob < AiBaseJob
+  private
+
+  def execute(blob_ids:)
+    update_progress(10)
+    blobs = ActiveStorage::Blob.where(id: blob_ids)
+
+    update_progress(20)
+    extractor = RecipeImport::PhotoExtractor.new(blobs.to_a)
+
+    update_progress(40)
+    recipe_data = extractor.extract
+
+    update_progress(90)
+    recipe_data.merge(method_used: "photo")
+  end
+end

--- a/app/services/recipe_import/photo_extractor.rb
+++ b/app/services/recipe_import/photo_extractor.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module RecipeImport
+  class PhotoExtractor
+    SYSTEM_PROMPT = <<~PROMPT
+      You are a recipe extraction assistant. Given one or more photos of a recipe
+      (cookbook page, handwritten card, screenshot, etc.), extract the recipe information
+      and return it using the provided tool.
+      If the images do not contain a recipe, return empty values.
+      For ingredients, include the full text as written (e.g. "2 cups almond flour").
+      For instructions, extract each step as a separate item.
+      Handle rotated or slightly skewed text gracefully.
+      If the recipe spans multiple images, combine the information from all images.
+    PROMPT
+
+    RECIPE_TOOL = RecipeImport::AiExtractor::RECIPE_TOOL
+
+    MAX_IMAGE_SIZE = 10.megabytes
+    SUPPORTED_CONTENT_TYPES = %w[image/jpeg image/png image/gif image/webp].freeze
+
+    def initialize(images, ai_client: nil)
+      @images = images.is_a?(Array) ? images : [ images ]
+      @ai_client = ai_client || Ai::Client.new
+    end
+
+    def extract
+      content = build_content_blocks
+      raise ExtractionError, "No valid images provided" if content.empty?
+
+      result = @ai_client.chat_with_tools(
+        messages: [ { role: "user", content: content } ],
+        tools: [ RECIPE_TOOL ],
+        system: SYSTEM_PROMPT,
+        max_tokens: 4096
+      )
+
+      normalize(result[:input])
+    end
+
+    class ExtractionError < StandardError; end
+
+    private
+
+    def build_content_blocks
+      blocks = @images.filter_map { |image| image_block(image) }
+      blocks << { type: "text", text: "Extract the recipe from these images." } if blocks.any?
+      blocks
+    end
+
+    def image_block(image)
+      data, media_type = encode_image(image)
+      return nil unless data
+
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: media_type,
+          data: data
+        }
+      }
+    end
+
+    def encode_image(image)
+      case image
+      when ActiveStorage::Blob
+        return nil unless valid_blob?(image)
+        [ Base64.strict_encode64(image.download), image.content_type ]
+      when Hash
+        # Direct base64 data: { data: "...", content_type: "image/jpeg" }
+        [ image[:data], image[:content_type] ]
+      end
+    end
+
+    def valid_blob?(blob)
+      SUPPORTED_CONTENT_TYPES.include?(blob.content_type) && blob.byte_size <= MAX_IMAGE_SIZE
+    end
+
+    def normalize(input)
+      instructions = (input["instructions"] || []).map.with_index(1) do |text, i|
+        { step_number: i, instruction: text }
+      end
+
+      nutrition = {
+        calories: input["calories"],
+        fat: input["fat"],
+        protein: input["protein"],
+        carbs: input["carbs"],
+        fiber: input["fiber"]
+      }.compact.presence
+
+      {
+        title: input["title"],
+        description: input["description"],
+        servings: input["servings"],
+        prep_time: input["prep_time"],
+        cook_time: input["cook_time"],
+        ingredients: input["ingredients"] || [],
+        instructions: instructions,
+        nutrition: nutrition
+      }.compact
+    end
+  end
+end

--- a/app/views/accounts/recipes/import_photo.html.erb
+++ b/app/views/accounts/recipes/import_photo.html.erb
@@ -1,0 +1,27 @@
+<div class="max-w-2xl mx-auto">
+  <h1 class="font-display font-bold text-3xl text-warm-900 mb-2">Import Recipe from Photo</h1>
+  <p class="text-warm-600 mb-8">Upload photos of a recipe page, cookbook, or handwritten card and we'll extract the details.</p>
+
+  <div class="card-warm p-8">
+    <%= form_with url: start_photo_import_recipes_path, method: :post, multipart: true, class: "space-y-6" do |f| %>
+      <div>
+        <%= f.label :photos, "Recipe Photos", class: "block text-sm font-medium text-warm-700 mb-1" %>
+        <%= f.file_field :photos,
+            multiple: true,
+            accept: "image/jpeg,image/png,image/gif,image/webp",
+            class: "w-full px-4 py-3 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-lg file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:bg-primary-50 file:text-primary-700 file:font-semibold hover:file:bg-primary-100 file:cursor-pointer",
+            required: true %>
+        <p class="mt-2 text-sm text-warm-500">Supports JPEG, PNG, GIF, and WebP. Upload multiple images for multi-page recipes.</p>
+      </div>
+
+      <div class="flex items-center gap-4">
+        <%= f.submit "Extract Recipe", class: "px-6 py-3 bg-primary-600 text-white font-semibold rounded-lg hover:bg-primary-700 transition-colors cursor-pointer" %>
+        <%= link_to "Cancel", recipes_path, class: "text-warm-600 hover:text-warm-800" %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="mt-6 text-center">
+    <p class="text-warm-500 text-sm">Or <%= link_to "import from URL", import_url_recipes_path, class: "text-primary-600 hover:text-primary-700 font-medium" %> instead.</p>
+  </div>
+</div>

--- a/app/views/accounts/recipes/import_status.html.erb
+++ b/app/views/accounts/recipes/import_status.html.erb
@@ -10,7 +10,7 @@
     </div>
 
     <p class="text-warm-600 text-lg">
-      We're extracting the recipe from the page. This usually takes a few seconds.
+      We're extracting the recipe details. This usually takes a few seconds.
     </p>
 
     <div class="w-full bg-warm-200 rounded-full h-2">

--- a/app/views/accounts/recipes/import_url.html.erb
+++ b/app/views/accounts/recipes/import_url.html.erb
@@ -21,4 +21,8 @@
       </div>
     <% end %>
   </div>
+
+  <div class="mt-6 text-center">
+    <p class="text-warm-500 text-sm">Or <%= link_to "import from a photo", import_photo_recipes_path, class: "text-primary-600 hover:text-primary-700 font-medium" %> instead.</p>
+  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,8 @@ Rails.application.routes.draw do
         get :search_usda
         get :import_url
         post :start_import
+        get :import_photo
+        post :start_photo_import
         get :import_status
         get :import_review
       end

--- a/test/controllers/accounts/recipes_controller_test.rb
+++ b/test/controllers/accounts/recipes_controller_test.rb
@@ -403,4 +403,60 @@ class Accounts::RecipesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "h1", "New Recipe"
   end
+
+  # --- Import Photo ---
+
+  test "import_photo shows photo upload form" do
+    sign_in_as(@session)
+    get "#{account_path_prefix}/recipes/import_photo"
+    assert_response :success
+    assert_select "h1", "Import Recipe from Photo"
+    assert_select "input[type='file']"
+  end
+
+  test "start_photo_import redirects when no photos" do
+    sign_in_as(@session)
+    post "#{account_path_prefix}/recipes/start_photo_import"
+    assert_redirected_to import_photo_recipes_path
+    assert_equal "Please select at least one photo.", flash[:alert]
+  end
+
+  test "start_photo_import creates task and redirects to status" do
+    sign_in_as(@session)
+
+    photo = fixture_file_upload("test_image.jpg", "image/jpeg")
+
+    assert_difference "AiTaskStatus.count" do
+      post "#{account_path_prefix}/recipes/start_photo_import", params: { photos: [ photo ] }
+    end
+
+    task = AiTaskStatus.order(created_at: :desc).first
+    assert_equal "recipe_photo_import", task.task_type
+    assert_redirected_to import_status_recipes_path(task_id: task.id)
+  end
+
+  test "import_status redirects to import_photo when photo task failed" do
+    sign_in_as(@session)
+    task = @account.ai_task_statuses.create!(task_type: "recipe_photo_import")
+    task.mark_processing!
+    task.mark_failed!(error_message: "Could not read image")
+
+    get "#{account_path_prefix}/recipes/import_status", params: { task_id: task.id }
+    assert_redirected_to import_photo_recipes_path
+    assert_match(/Could not read image/, flash[:alert])
+  end
+
+  test "import_url page links to photo import" do
+    sign_in_as(@session)
+    get "#{account_path_prefix}/recipes/import_url"
+    assert_response :success
+    assert_select "a[href=?]", import_photo_recipes_path
+  end
+
+  test "import_photo page links to URL import" do
+    sign_in_as(@session)
+    get "#{account_path_prefix}/recipes/import_photo"
+    assert_response :success
+    assert_select "a[href=?]", import_url_recipes_path
+  end
 end

--- a/test/jobs/recipe_import_photo_job_test.rb
+++ b/test/jobs/recipe_import_photo_job_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RecipeImportPhotoJobTest < ActiveSupport::TestCase
+  test "job is enqueued on ai queue" do
+    assert_equal "ai", RecipeImportPhotoJob.new.queue_name
+  end
+
+  test "job inherits from AiBaseJob" do
+    assert RecipeImportPhotoJob < AiBaseJob
+  end
+end

--- a/test/services/recipe_import/photo_extractor_test.rb
+++ b/test/services/recipe_import/photo_extractor_test.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RecipeImport::PhotoExtractorTest < ActiveSupport::TestCase
+  # Fake AI client that returns a predetermined tool_use result
+  class FakeAiClient
+    attr_reader :last_call
+
+    def initialize(tool_input)
+      @tool_input = tool_input
+    end
+
+    def chat_with_tools(messages:, tools:, system: nil, max_tokens: 4096)
+      @last_call = { messages: messages, tools: tools, system: system, max_tokens: max_tokens }
+      { name: "extract_recipe", input: @tool_input }
+    end
+  end
+
+  test "extracts recipe data from image via AI" do
+    fake_client = FakeAiClient.new({
+      "title" => "Grandma's Keto Cookies",
+      "description" => "Low carb cookies from a handwritten recipe card",
+      "servings" => 24,
+      "prep_time" => 15,
+      "cook_time" => 12,
+      "ingredients" => [ "2 cups almond flour", "1/2 cup butter", "1 egg" ],
+      "instructions" => [ "Mix dry ingredients", "Add wet ingredients", "Bake at 350F" ],
+      "calories" => 95.0,
+      "fat" => 8.0,
+      "protein" => 3.0,
+      "carbs" => 1.5
+    })
+
+    image = { data: Base64.strict_encode64("fake image data"), content_type: "image/jpeg" }
+    extractor = RecipeImport::PhotoExtractor.new(image, ai_client: fake_client)
+    result = extractor.extract
+
+    assert_equal "Grandma's Keto Cookies", result[:title]
+    assert_equal 24, result[:servings]
+    assert_equal 3, result[:ingredients].length
+    assert_equal 3, result[:instructions].length
+    assert_equal 1, result[:instructions].first[:step_number]
+    assert_equal "Mix dry ingredients", result[:instructions].first[:instruction]
+    assert_equal 95.0, result[:nutrition][:calories]
+  end
+
+  test "handles multiple images" do
+    fake_client = FakeAiClient.new({
+      "title" => "Multi-Page Recipe",
+      "ingredients" => [ "flour", "sugar" ],
+      "instructions" => [ "Mix", "Bake" ]
+    })
+
+    images = [
+      { data: Base64.strict_encode64("page 1"), content_type: "image/jpeg" },
+      { data: Base64.strict_encode64("page 2"), content_type: "image/png" }
+    ]
+    extractor = RecipeImport::PhotoExtractor.new(images, ai_client: fake_client)
+    result = extractor.extract
+
+    assert_equal "Multi-Page Recipe", result[:title]
+
+    # Verify both images were sent in the message
+    content = fake_client.last_call[:messages].first[:content]
+    image_blocks = content.select { |b| b[:type] == "image" }
+    assert_equal 2, image_blocks.length
+  end
+
+  test "sends text prompt after images" do
+    fake_client = FakeAiClient.new({
+      "title" => "Test",
+      "ingredients" => [ "water" ],
+      "instructions" => [ "boil" ]
+    })
+
+    image = { data: Base64.strict_encode64("data"), content_type: "image/jpeg" }
+    RecipeImport::PhotoExtractor.new(image, ai_client: fake_client).extract
+
+    content = fake_client.last_call[:messages].first[:content]
+    text_block = content.find { |b| b[:type] == "text" }
+    assert_not_nil text_block
+    assert_includes text_block[:text], "Extract the recipe"
+  end
+
+  test "raises ExtractionError when no valid images" do
+    fake_client = FakeAiClient.new({})
+
+    error = assert_raises(RecipeImport::PhotoExtractor::ExtractionError) do
+      RecipeImport::PhotoExtractor.new([], ai_client: fake_client).extract
+    end
+    assert_match(/No valid images/, error.message)
+  end
+
+  test "handles missing nutrition gracefully" do
+    fake_client = FakeAiClient.new({
+      "title" => "Simple Recipe",
+      "ingredients" => [ "1 egg" ],
+      "instructions" => [ "Cook it" ]
+    })
+
+    image = { data: Base64.strict_encode64("data"), content_type: "image/jpeg" }
+    result = RecipeImport::PhotoExtractor.new(image, ai_client: fake_client).extract
+
+    assert_nil result[:nutrition]
+  end
+
+  test "normalizes instructions with step numbers" do
+    fake_client = FakeAiClient.new({
+      "title" => "Test",
+      "ingredients" => [ "water" ],
+      "instructions" => [ "Step A", "Step B", "Step C" ]
+    })
+
+    image = { data: Base64.strict_encode64("data"), content_type: "image/jpeg" }
+    result = RecipeImport::PhotoExtractor.new(image, ai_client: fake_client).extract
+
+    assert_equal 1, result[:instructions][0][:step_number]
+    assert_equal 2, result[:instructions][1][:step_number]
+    assert_equal 3, result[:instructions][2][:step_number]
+  end
+
+  test "reuses RECIPE_TOOL from AiExtractor" do
+    assert_equal RecipeImport::AiExtractor::RECIPE_TOOL, RecipeImport::PhotoExtractor::RECIPE_TOOL
+  end
+
+  test "wraps single image in array" do
+    fake_client = FakeAiClient.new({
+      "title" => "Test",
+      "ingredients" => [ "water" ],
+      "instructions" => [ "boil" ]
+    })
+
+    image = { data: Base64.strict_encode64("data"), content_type: "image/jpeg" }
+    result = RecipeImport::PhotoExtractor.new(image, ai_client: fake_client).extract
+
+    assert_equal "Test", result[:title]
+  end
+
+  test "supports ActiveStorage blobs" do
+    fake_client = FakeAiClient.new({
+      "title" => "Blob Recipe",
+      "ingredients" => [ "flour" ],
+      "instructions" => [ "mix" ]
+    })
+
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new("fake jpeg data"),
+      filename: "recipe.jpg",
+      content_type: "image/jpeg"
+    )
+
+    result = RecipeImport::PhotoExtractor.new(blob, ai_client: fake_client).extract
+    assert_equal "Blob Recipe", result[:title]
+
+    # Verify the blob data was base64 encoded in the message
+    content = fake_client.last_call[:messages].first[:content]
+    image_block = content.find { |b| b[:type] == "image" }
+    assert_equal "image/jpeg", image_block[:source][:media_type]
+    assert_equal Base64.strict_encode64("fake jpeg data"), image_block[:source][:data]
+  end
+
+  test "skips blobs with unsupported content types" do
+    fake_client = FakeAiClient.new({})
+
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new("fake data"),
+      filename: "recipe.pdf",
+      content_type: "application/pdf"
+    )
+
+    error = assert_raises(RecipeImport::PhotoExtractor::ExtractionError) do
+      RecipeImport::PhotoExtractor.new(blob, ai_client: fake_client).extract
+    end
+    assert_match(/No valid images/, error.message)
+  end
+end


### PR DESCRIPTION
## Summary

Adds photo-based recipe import using Claude's vision capabilities. Users can upload one or more photos of recipes (cookbook pages, handwritten cards, screenshots) and the system extracts structured recipe data via AI for review before saving.

## Changes

- `app/services/recipe_import/photo_extractor.rb` — Vision-based extraction service using Claude's tool_use with image content blocks. Supports Active Storage blobs and raw base64 data, multi-image, max 10MB/image, JPEG/PNG/GIF/WebP.
- `app/jobs/recipe_import_photo_job.rb` — Async job extending AiBaseJob with progress tracking
- `app/controllers/accounts/recipes_controller.rb` — `import_photo` and `start_photo_import` actions; updated `import_status` to route failure redirects based on task type
- `config/routes.rb` — Added `import_photo` and `start_photo_import` collection routes
- `app/views/accounts/recipes/import_photo.html.erb` — Multi-file upload form
- `app/views/accounts/recipes/import_url.html.erb` — Added cross-link to photo import
- `app/views/accounts/recipes/import_status.html.erb` — Generalized status message
- `CLAUDE.md` — Updated Recipe Import Pipeline documentation

## Documentation

- CLAUDE.md: Updated Recipe Import Pipeline section with photo import details

## Testing

- 12 unit tests for PhotoExtractor (AI extraction, multi-image, blob support, edge cases)
- 2 job tests for RecipeImportPhotoJob
- 6 new controller integration tests for photo import flow
- All 667 tests pass, Rubocop: 0 offenses, Brakeman: 0 warnings

Closes #9