### PR TITLE
Upgrade navigation with brand mark, active states, and promoted links

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -69,6 +69,19 @@
   background: linear-gradient(135deg, #7d381c 0%, #a14722 40%, #c2582a 100%);
 }
 
+/* Nav active link — saffron underline indicator */
+.nav-link-active::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 1.25rem;
+  height: 2px;
+  background: var(--color-accent-300);
+  border-radius: 9999px;
+}
+
 /* Macro donut chart — ring mask */
 .macro-donut {
   -webkit-mask: radial-gradient(circle, transparent 55%, black 56%);

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -1,13 +1,44 @@
 module NavigationHelper
-  def nav_link_to(name, path, controller_match:)
+  def nav_link_to(name, path, controller_match:, icon: nil)
     active = controller_match.include?(controller_name)
 
+    base = "relative inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium transition-colors duration-150"
+
     css = if active
-      "bg-primary-800 text-white rounded-md px-3 py-2 text-sm font-medium"
+      "#{base} text-white nav-link-active"
     else
-      "text-primary-100 hover:bg-primary-600 hover:text-white rounded-md px-3 py-2 text-sm font-medium"
+      "#{base} text-primary-200 hover:text-white"
     end
 
-    link_to name, path, class: css
+    link_to path, class: css do
+      safe_join([ icon, name ].compact)
+    end
+  end
+
+  def mobile_drawer_link(name, path, controller_match:, icon: nil)
+    active = controller_match.include?(controller_name)
+
+    base = "flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors"
+    css = if active
+      "#{base} bg-white/15 text-white"
+    else
+      "#{base} text-primary-200 hover:bg-white/10 hover:text-white"
+    end
+
+    link_to path, class: css do
+      parts = []
+      if icon
+        parts << tag.svg(
+          class: "w-5 h-5",
+          fill: "none",
+          viewBox: "0 0 24 24",
+          stroke_width: "1.5",
+          stroke: "currentColor",
+          aria: { hidden: true }
+        ) { tag.path(stroke_linecap: "round", stroke_linejoin: "round", d: icon) }
+      end
+      parts << name
+      safe_join(parts)
+    end
   end
 end

--- a/app/javascript/controllers/mobile_nav_controller.js
+++ b/app/javascript/controllers/mobile_nav_controller.js
@@ -1,9 +1,58 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["menu"]
+  static targets = ["drawer", "backdrop"]
+
+  connect() {
+    this.isOpen = false
+  }
 
   toggle() {
-    this.menuTarget.classList.toggle("hidden")
+    if (this.isOpen) {
+      this.close()
+    } else {
+      this.open()
+    }
+  }
+
+  open() {
+    this.isOpen = true
+    this.drawerTarget.classList.remove("hidden")
+    this.backdropTarget.classList.remove("hidden")
+
+    // Force reflow before animating
+    this.drawerTarget.offsetHeight
+
+    requestAnimationFrame(() => {
+      this.backdropTarget.classList.remove("opacity-0")
+      this.backdropTarget.classList.add("opacity-100")
+      this.drawerTarget.classList.remove("translate-x-full")
+      this.drawerTarget.classList.add("translate-x-0")
+    })
+  }
+
+  close() {
+    this.isOpen = false
+    this.backdropTarget.classList.remove("opacity-100")
+    this.backdropTarget.classList.add("opacity-0")
+    this.drawerTarget.classList.remove("translate-x-0")
+    this.drawerTarget.classList.add("translate-x-full")
+
+    setTimeout(() => {
+      this.drawerTarget.classList.add("hidden")
+      this.backdropTarget.classList.add("hidden")
+    }, 300)
+  }
+
+  closeOnBackdrop(event) {
+    if (event.target === this.backdropTarget) {
+      this.close()
+    }
+  }
+
+  closeOnEscape(event) {
+    if (event.key === "Escape" && this.isOpen) {
+      this.close()
+    }
   }
 }

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,42 +1,52 @@
-<nav class="nav-warm" data-controller="mobile-nav">
+<nav class="nav-warm relative z-40" data-controller="mobile-nav" data-action="keydown@window->mobile-nav#closeOnEscape">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex items-center justify-between h-16">
       <div class="flex items-center">
+        <%# Brand wordmark with flame icon %>
         <div class="shrink-0">
-          <%= link_to "MealSzn", account_root_path, class: "text-white font-display font-bold text-xl" %>
+          <%= link_to account_root_path, class: "group flex items-center gap-2 text-white no-underline" do %>
+            <svg class="w-7 h-7 text-accent-300 transition-transform duration-300 group-hover:rotate-12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M12 2C10.5 6 7 8 7 12.5C7 16.09 9.69 19 13 19C13 19 12 17 12 15C12 12.5 14 11 15 9C16 7 14 2 12 2Z" opacity="0.3"/>
+              <path d="M12 2C10 6.5 6 9 6 13C6 17.42 9.58 21 14 21C14 21 12.5 18.5 12.5 16C12.5 13 15 11.5 16 9C17 6.5 14.5 2 12 2Z" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            <span class="font-display font-bold text-xl tracking-tight">MealSzn</span>
+          <% end %>
         </div>
+
+        <%# Desktop navigation links %>
         <div class="hidden md:block">
-          <div class="ml-10 flex items-baseline space-x-4">
+          <div class="ml-10 flex items-baseline space-x-1">
             <%= nav_link_to "Dashboard", account_root_path, controller_match: %w[dashboards] %>
             <%= nav_link_to "Recipes", recipes_path, controller_match: %w[recipes] %>
             <%= nav_link_to "Meal Plans", meal_plans_path, controller_match: %w[meal_plans meal_plan_meals shopping_lists shopping_list_items] %>
+            <%= nav_link_to "Family", dietary_profiles_path, controller_match: %w[dietary_profiles] %>
           </div>
         </div>
       </div>
 
       <%# Desktop user menu %>
       <div class="hidden md:block" data-controller="dropdown">
-        <button type="button" data-action="dropdown#toggle" class="flex items-center text-primary-100 hover:text-white text-sm font-medium focus:outline-none">
+        <button type="button" data-action="dropdown#toggle" class="flex items-center text-primary-200 hover:text-white text-sm font-medium focus:outline-none transition-colors duration-150">
           <span><%= Current.user.name %></span>
           <svg class="ml-1 h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
             <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
           </svg>
         </button>
 
-        <div data-dropdown-target="menu" class="hidden absolute right-4 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50">
+        <div data-dropdown-target="menu" class="hidden absolute right-4 mt-2 w-56 rounded-xl shadow-lg bg-white ring-1 ring-warm-200 z-50">
           <div class="py-1">
             <div class="px-4 py-2 text-xs text-warm-500"><%= Current.identity.email_address %></div>
             <hr class="border-warm-100">
-            <%= link_to "Settings", settings_path, class: "block px-4 py-2 text-sm text-warm-700 hover:bg-warm-100" %>
+            <%= link_to "Settings", settings_path, class: "block px-4 py-2 text-sm text-warm-700 hover:bg-warm-50 transition-colors" %>
             <hr class="border-warm-100">
-            <%= button_to "Sign Out", session_path, method: :delete, class: "w-full text-left block px-4 py-2 text-sm text-warm-700 hover:bg-warm-100" %>
+            <%= button_to "Sign Out", session_path, method: :delete, class: "w-full text-left block px-4 py-2 text-sm text-warm-700 hover:bg-warm-50 transition-colors" %>
           </div>
         </div>
       </div>
 
       <%# Mobile hamburger button %>
       <div class="md:hidden">
-        <button type="button" data-action="mobile-nav#toggle" class="inline-flex items-center justify-center p-2 rounded-md text-primary-200 hover:text-white hover:bg-primary-600 focus:outline-none">
+        <button type="button" data-action="mobile-nav#toggle" class="inline-flex items-center justify-center p-2 rounded-lg text-primary-200 hover:text-white hover:bg-white/10 focus:outline-none transition-colors duration-150">
           <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
           </svg>
@@ -45,22 +55,67 @@
     </div>
   </div>
 
-  <%# Mobile menu panel %>
-  <div data-mobile-nav-target="menu" class="hidden md:hidden">
-    <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
-      <%= nav_link_to "Dashboard", account_root_path, controller_match: %w[dashboards] %>
-      <%= nav_link_to "Recipes", recipes_path, controller_match: %w[recipes] %>
-      <%= nav_link_to "Meal Plans", meal_plans_path, controller_match: %w[meal_plans meal_plan_meals shopping_lists shopping_list_items] %>
+  <%# Mobile backdrop %>
+  <div
+    data-mobile-nav-target="backdrop"
+    data-action="click->mobile-nav#closeOnBackdrop"
+    class="hidden fixed inset-0 bg-black/40 opacity-0 transition-opacity duration-300 z-40 md:hidden"
+  ></div>
+
+  <%# Mobile slide-over drawer %>
+  <div
+    data-mobile-nav-target="drawer"
+    class="hidden fixed top-0 right-0 h-full w-72 translate-x-full transition-transform duration-300 ease-out z-50 md:hidden nav-warm shadow-2xl"
+  >
+    <%# Drawer header with close button %>
+    <div class="flex items-center justify-between px-5 pt-5 pb-3">
+      <div class="flex items-center gap-2">
+        <svg class="w-6 h-6 text-accent-300" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M12 2C10.5 6 7 8 7 12.5C7 16.09 9.69 19 13 19C13 19 12 17 12 15C12 12.5 14 11 15 9C16 7 14 2 12 2Z" opacity="0.3"/>
+          <path d="M12 2C10 6.5 6 9 6 13C6 17.42 9.58 21 14 21C14 21 12.5 18.5 12.5 16C12.5 13 15 11.5 16 9C17 6.5 14.5 2 12 2Z" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span class="font-display font-bold text-lg text-white">MealSzn</span>
+      </div>
+      <button type="button" data-action="mobile-nav#close" class="p-1.5 rounded-lg text-primary-200 hover:text-white hover:bg-white/10 transition-colors">
+        <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
     </div>
-    <div class="border-t border-primary-600 pt-4 pb-3">
-      <div class="px-4">
-        <div class="text-base font-medium text-white"><%= Current.user.name %></div>
-        <div class="text-sm text-primary-200"><%= Current.identity.email_address %></div>
-      </div>
-      <div class="mt-3 px-2 space-y-1">
-        <%= link_to "Settings", settings_path, class: "block rounded-md px-3 py-2 text-base font-medium text-primary-200 hover:bg-primary-600 hover:text-white" %>
-        <%= button_to "Sign Out", session_path, method: :delete, class: "w-full text-left block rounded-md px-3 py-2 text-base font-medium text-primary-200 hover:bg-primary-600 hover:text-white" %>
-      </div>
+
+    <%# User info %>
+    <div class="px-5 py-3 border-b border-white/10">
+      <div class="text-sm font-medium text-white"><%= Current.user.name %></div>
+      <div class="text-xs text-primary-300 mt-0.5"><%= Current.identity.email_address %></div>
+    </div>
+
+    <%# Navigation links %>
+    <div class="px-3 py-4 space-y-1">
+      <%= mobile_drawer_link "Dashboard", account_root_path, controller_match: %w[dashboards],
+          icon: "M2.25 12l8.954-8.955a1.126 1.126 0 011.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" %>
+      <%= mobile_drawer_link "Recipes", recipes_path, controller_match: %w[recipes],
+          icon: "M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" %>
+      <%= mobile_drawer_link "Meal Plans", meal_plans_path, controller_match: %w[meal_plans meal_plan_meals shopping_lists shopping_list_items],
+          icon: "M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" %>
+      <%= mobile_drawer_link "Family", dietary_profiles_path, controller_match: %w[dietary_profiles],
+          icon: "M18 18.72a9.094 9.094 0 003.741-2.706 9.042 9.042 0 00-7.741-3.764 9.042 9.042 0 00-7.741 3.764 9.094 9.094 0 003.741 2.706M12 6.75a3.75 3.75 0 110 7.5 3.75 3.75 0 010-7.5zM12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25z" %>
+    </div>
+
+    <%# Bottom section %>
+    <div class="absolute bottom-0 left-0 right-0 px-3 pb-6 pt-3 border-t border-white/10">
+      <%= link_to settings_path, class: "flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm text-primary-200 hover:bg-white/10 hover:text-white transition-colors" do %>
+        <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+        </svg>
+        Settings
+      <% end %>
+      <%= button_to session_path, method: :delete, class: "w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm text-primary-200 hover:bg-white/10 hover:text-white transition-colors" do %>
+        <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15m3 0l3-3m0 0l-3-3m3 3H9" />
+        </svg>
+        Sign Out
+      <% end %>
     </div>
   </div>
 </nav>

--- a/test/helpers/navigation_helper_test.rb
+++ b/test/helpers/navigation_helper_test.rb
@@ -1,0 +1,73 @@
+require "test_helper"
+
+class NavigationHelperTest < ActionView::TestCase
+  include NavigationHelper
+
+  # Stub controller_name for testing active state detection
+  attr_accessor :stubbed_controller_name
+
+  def controller_name
+    stubbed_controller_name || "dashboards"
+  end
+
+  test "nav_link_to renders active state with nav-link-active class" do
+    self.stubbed_controller_name = "recipes"
+    html = nav_link_to("Recipes", "/recipes", controller_match: %w[recipes])
+
+    assert_includes html, "nav-link-active"
+    assert_includes html, "text-white"
+    assert_includes html, "Recipes"
+  end
+
+  test "nav_link_to renders inactive state without nav-link-active class" do
+    self.stubbed_controller_name = "dashboards"
+    html = nav_link_to("Recipes", "/recipes", controller_match: %w[recipes])
+
+    assert_not_includes html, "nav-link-active"
+    assert_includes html, "text-primary-200"
+    assert_includes html, "hover:text-white"
+  end
+
+  test "nav_link_to matches multiple controller names" do
+    self.stubbed_controller_name = "shopping_lists"
+    html = nav_link_to("Meal Plans", "/meal_plans", controller_match: %w[meal_plans shopping_lists])
+
+    assert_includes html, "nav-link-active"
+  end
+
+  test "nav_link_to generates correct link path" do
+    html = nav_link_to("Dashboard", "/dashboard", controller_match: %w[dashboards])
+
+    assert_includes html, 'href="/dashboard"'
+  end
+
+  test "mobile_drawer_link renders active state with bg-white/15" do
+    self.stubbed_controller_name = "recipes"
+    html = mobile_drawer_link("Recipes", "/recipes", controller_match: %w[recipes], icon: "M12 6v12")
+
+    assert_includes html, "bg-white/15"
+    assert_includes html, "Recipes"
+  end
+
+  test "mobile_drawer_link renders inactive state" do
+    self.stubbed_controller_name = "dashboards"
+    html = mobile_drawer_link("Recipes", "/recipes", controller_match: %w[recipes], icon: "M12 6v12")
+
+    assert_not_includes html, "bg-white/15"
+    assert_includes html, "text-primary-200"
+  end
+
+  test "mobile_drawer_link renders SVG icon when provided" do
+    html = mobile_drawer_link("Dashboard", "/", controller_match: %w[other], icon: "M2.25 12l8.954-8.955")
+
+    assert_includes html, "<svg"
+    assert_includes html, "M2.25 12l8.954-8.955"
+  end
+
+  test "mobile_drawer_link works without icon" do
+    html = mobile_drawer_link("Dashboard", "/", controller_match: %w[other])
+
+    assert_not_includes html, "<svg"
+    assert_includes html, "Dashboard"
+  end
+end


### PR DESCRIPTION
## Summary

Transforms the navigation bar from a generic admin header into a branded, distinctive navigation with a flame icon mark, saffron underline active states, promoted Dietary Profiles link, and a mobile slide-over drawer.

## Changes

- **Brand wordmark**: Added inline SVG flame icon beside "MealSzn" text with hover rotation animation (`group-hover:rotate-12`)
- **Active states**: Replaced background-color swap with a visible saffron (`accent-300`) underline indicator via `.nav-link-active::after` CSS pseudo-element
- **Promoted Dietary Profiles**: Added "Family" as a main nav item linking to `dietary_profiles_path` alongside Dashboard, Recipes, Meal Plans
- **Mobile slide-over drawer**: Converted simple dropdown panel to a right-sliding drawer with:
  - Backdrop overlay with fade transition
  - Slide-in/out animation (300ms ease-out)
  - User info (name, email) in header
  - Icon-enhanced navigation links
  - Settings and Sign Out pinned to bottom
  - Close on backdrop tap or Escape key
- **Navigation helper**: Updated `nav_link_to` to use underline active styling, added `mobile_drawer_link` helper with SVG icon support
- **Dropdown menu**: Rounded corners upgraded to `rounded-xl`, subtle warm border

## Documentation

- README.md: No changes needed
- CLAUDE.md: No changes needed

## Testing

- 8 new navigation helper tests covering active/inactive states, controller matching, icon rendering
- Full test suite: 657 tests, 0 failures
- Rubocop: 0 offenses on changed files
- Brakeman: no warnings

Closes #37