### PR TITLE
Add AI-assisted quick recipe entry

### DIFF
--- a/app/controllers/accounts/recipes_controller.rb
+++ b/app/controllers/accounts/recipes_controller.rb
@@ -143,14 +143,30 @@ class Accounts::RecipesController < ApplicationController
     redirect_to import_status_recipes_path(task_id: task.id)
   end
 
+  def quick_entry
+    @description = params[:description]
+  end
+
+  def start_quick_entry
+    description = params[:description].to_s.strip
+    if description.blank?
+      redirect_to quick_entry_recipes_path, alert: "Please describe the recipe you want to create."
+      return
+    end
+
+    task = Current.account.ai_task_statuses.create!(task_type: "recipe_generate")
+    RecipeGenerateJob.perform_later(task.id, description: description, diet_name: Current.account.default_diet_name)
+
+    redirect_to import_status_recipes_path(task_id: task.id)
+  end
+
   def import_status
     @task = Current.account.ai_task_statuses.find(params[:task_id])
 
     if @task.completed?
       redirect_to import_review_recipes_path(task_id: @task.id)
     elsif @task.failed?
-      failure_path = @task.task_type == "recipe_photo_import" ? import_photo_recipes_path : import_url_recipes_path
-      redirect_to failure_path, alert: "Import failed: #{@task.error_message}"
+      redirect_to failure_path_for(@task), alert: "Import failed: #{@task.error_message}"
     end
   end
 
@@ -198,6 +214,16 @@ class Accounts::RecipesController < ApplicationController
   end
 
   private
+
+  FAILURE_PATHS = {
+    "recipe_photo_import" => :import_photo_recipes_path,
+    "recipe_generate" => :quick_entry_recipes_path
+  }.freeze
+
+  def failure_path_for(task)
+    method_name = FAILURE_PATHS[task.task_type] || :import_url_recipes_path
+    send(method_name)
+  end
 
   def set_recipe
     @recipe = Current.account.recipes

--- a/app/jobs/recipe_generate_job.rb
+++ b/app/jobs/recipe_generate_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class RecipeGenerateJob < AiBaseJob
+  private
+
+  def execute(description:, diet_name: nil)
+    update_progress(10)
+    generator = RecipeImport::AiGenerator.new(description, diet_name: diet_name)
+
+    update_progress(30)
+    recipe_data = generator.generate
+
+    update_progress(90)
+    recipe_data.merge(method_used: "ai_generated")
+  end
+end

--- a/app/services/recipe_import/ai_generator.rb
+++ b/app/services/recipe_import/ai_generator.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module RecipeImport
+  class AiGenerator
+    class GenerationError < StandardError; end
+
+    RECIPE_TOOL = RecipeImport::AiExtractor::RECIPE_TOOL
+
+    def initialize(description, diet_name: nil, ai_client: nil)
+      @description = description
+      @diet_name = diet_name
+      @ai_client = ai_client || Ai::Client.new
+    end
+
+    def generate
+      result = @ai_client.chat_with_tools(
+        messages: [ { role: "user", content: user_prompt } ],
+        tools: [ RECIPE_TOOL ],
+        system: system_prompt,
+        max_tokens: 4096
+      )
+
+      normalize(result[:input])
+    end
+
+    private
+
+    def system_prompt
+      prompt = <<~PROMPT
+        You are an expert chef and recipe creator. Given a brief description of a dish,
+        generate a complete, detailed recipe with accurate ingredient quantities,
+        clear step-by-step instructions, and estimated nutrition data per serving.
+        Use the provided tool to return the structured recipe data.
+        Be specific with quantities (e.g. "2 tablespoons butter" not just "butter").
+        Include realistic prep and cook times.
+        Estimate nutrition values per serving as accurately as possible.
+      PROMPT
+
+      if @diet_name.present?
+        prompt += "\nIMPORTANT: This recipe must be appropriate for a #{@diet_name} diet. " \
+                  "Choose ingredients and quantities that fit this dietary approach."
+      end
+
+      prompt
+    end
+
+    def user_prompt
+      "Create a recipe for: #{@description}"
+    end
+
+    def normalize(input)
+      instructions = (input["instructions"] || []).map.with_index(1) do |text, i|
+        { step_number: i, instruction: text }
+      end
+
+      nutrition = {
+        calories: input["calories"],
+        fat: input["fat"],
+        protein: input["protein"],
+        carbs: input["carbs"],
+        fiber: input["fiber"]
+      }.compact.presence
+
+      {
+        title: input["title"],
+        description: input["description"],
+        servings: input["servings"],
+        prep_time: input["prep_time"],
+        cook_time: input["cook_time"],
+        ingredients: input["ingredients"] || [],
+        instructions: instructions,
+        nutrition: nutrition
+      }.compact
+    end
+  end
+end

--- a/app/views/accounts/recipes/import_photo.html.erb
+++ b/app/views/accounts/recipes/import_photo.html.erb
@@ -21,7 +21,7 @@
     <% end %>
   </div>
 
-  <div class="mt-6 text-center">
-    <p class="text-warm-500 text-sm">Or <%= link_to "import from URL", import_url_recipes_path, class: "text-primary-600 hover:text-primary-700 font-medium" %> instead.</p>
+  <div class="mt-6 text-center space-y-1">
+    <p class="text-warm-500 text-sm">Or <%= link_to "import from URL", import_url_recipes_path, class: "text-primary-600 hover:text-primary-700 font-medium" %> or <%= link_to "generate with AI", quick_entry_recipes_path, class: "text-primary-600 hover:text-primary-700 font-medium" %> instead.</p>
   </div>
 </div>

--- a/app/views/accounts/recipes/import_url.html.erb
+++ b/app/views/accounts/recipes/import_url.html.erb
@@ -22,7 +22,7 @@
     <% end %>
   </div>
 
-  <div class="mt-6 text-center">
-    <p class="text-warm-500 text-sm">Or <%= link_to "import from a photo", import_photo_recipes_path, class: "text-primary-600 hover:text-primary-700 font-medium" %> instead.</p>
+  <div class="mt-6 text-center space-y-1">
+    <p class="text-warm-500 text-sm">Or <%= link_to "import from a photo", import_photo_recipes_path, class: "text-primary-600 hover:text-primary-700 font-medium" %> or <%= link_to "generate with AI", quick_entry_recipes_path, class: "text-primary-600 hover:text-primary-700 font-medium" %> instead.</p>
   </div>
 </div>

--- a/app/views/accounts/recipes/quick_entry.html.erb
+++ b/app/views/accounts/recipes/quick_entry.html.erb
@@ -1,0 +1,38 @@
+<div class="max-w-2xl mx-auto">
+  <h1 class="font-display font-bold text-3xl text-warm-900 mb-2">Quick Recipe Entry</h1>
+  <p class="text-warm-600 mb-8">Describe a dish and we'll generate a complete recipe with ingredients, instructions, and nutrition.</p>
+
+  <div class="card-warm p-8">
+    <%= form_with url: start_quick_entry_recipes_path, method: :post, class: "space-y-6" do |f| %>
+      <div>
+        <%= f.label :description, "What do you want to cook?", class: "block text-sm font-medium text-warm-700 mb-1" %>
+        <%= f.text_area :description,
+            value: @description,
+            placeholder: "e.g. bacon wrapped chicken thighs with cream cheese filling",
+            rows: 3,
+            class: "w-full px-4 py-3 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-lg",
+            required: true,
+            autofocus: true %>
+        <p class="mt-2 text-sm text-warm-500">Be as specific as you like — mention flavors, cooking methods, or dietary needs.</p>
+      </div>
+
+      <% if Current.account.default_diet_name.present? %>
+        <div class="flex items-center gap-2 p-3 bg-primary-50 rounded-lg">
+          <svg class="h-5 w-5 text-primary-600 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+          </svg>
+          <span class="text-sm text-primary-700">Recipe will be tailored for <strong><%= Current.account.default_diet_name %></strong> diet.</span>
+        </div>
+      <% end %>
+
+      <div class="flex items-center gap-4">
+        <%= f.submit "Generate Recipe", class: "px-6 py-3 bg-primary-600 text-white font-semibold rounded-lg hover:bg-primary-700 transition-colors cursor-pointer" %>
+        <%= link_to "Cancel", recipes_path, class: "text-warm-600 hover:text-warm-800" %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="mt-6 text-center space-y-1">
+    <p class="text-warm-500 text-sm">Or import from <%= link_to "URL", import_url_recipes_path, class: "text-primary-600 hover:text-primary-700 font-medium" %> or <%= link_to "photo", import_photo_recipes_path, class: "text-primary-600 hover:text-primary-700 font-medium" %> instead.</p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,8 @@ Rails.application.routes.draw do
         post :start_import
         get :import_photo
         post :start_photo_import
+        get :quick_entry
+        post :start_quick_entry
         get :import_status
         get :import_review
       end

--- a/test/controllers/accounts/recipes_controller_test.rb
+++ b/test/controllers/accounts/recipes_controller_test.rb
@@ -459,4 +459,61 @@ class Accounts::RecipesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "a[href=?]", import_url_recipes_path
   end
+
+  # --- Quick Entry ---
+
+  test "quick_entry shows text input form" do
+    sign_in_as(@session)
+    get "#{account_path_prefix}/recipes/quick_entry"
+    assert_response :success
+    assert_select "h1", "Quick Recipe Entry"
+    assert_select "textarea"
+  end
+
+  test "start_quick_entry redirects when description is blank" do
+    sign_in_as(@session)
+    post "#{account_path_prefix}/recipes/start_quick_entry", params: { description: "" }
+    assert_redirected_to quick_entry_recipes_path
+    assert_equal "Please describe the recipe you want to create.", flash[:alert]
+  end
+
+  test "start_quick_entry creates task and redirects to status" do
+    sign_in_as(@session)
+
+    assert_difference "AiTaskStatus.count" do
+      post "#{account_path_prefix}/recipes/start_quick_entry", params: { description: "bacon wrapped chicken" }
+    end
+
+    task = AiTaskStatus.order(created_at: :desc).first
+    assert_equal "recipe_generate", task.task_type
+    assert_redirected_to import_status_recipes_path(task_id: task.id)
+  end
+
+  test "import_status redirects to quick_entry when generate task failed" do
+    sign_in_as(@session)
+    task = @account.ai_task_statuses.create!(task_type: "recipe_generate")
+    task.mark_processing!
+    task.mark_failed!(error_message: "Generation failed")
+
+    get "#{account_path_prefix}/recipes/import_status", params: { task_id: task.id }
+    assert_redirected_to quick_entry_recipes_path
+    assert_match(/Generation failed/, flash[:alert])
+  end
+
+  test "quick_entry shows diet badge when account has default diet" do
+    sign_in_as(@session)
+    @account.update!(default_diet_name: "Ketogenic (Keto)")
+
+    get "#{account_path_prefix}/recipes/quick_entry"
+    assert_response :success
+    assert_select "strong", "Ketogenic (Keto)"
+  end
+
+  test "quick_entry page links to other import methods" do
+    sign_in_as(@session)
+    get "#{account_path_prefix}/recipes/quick_entry"
+    assert_response :success
+    assert_select "a[href=?]", import_url_recipes_path
+    assert_select "a[href=?]", import_photo_recipes_path
+  end
 end

--- a/test/jobs/recipe_generate_job_test.rb
+++ b/test/jobs/recipe_generate_job_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RecipeGenerateJobTest < ActiveSupport::TestCase
+  test "job is enqueued on ai queue" do
+    assert_equal "ai", RecipeGenerateJob.new.queue_name
+  end
+
+  test "job inherits from AiBaseJob" do
+    assert RecipeGenerateJob < AiBaseJob
+  end
+end

--- a/test/services/recipe_import/ai_generator_test.rb
+++ b/test/services/recipe_import/ai_generator_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RecipeImport::AiGeneratorTest < ActiveSupport::TestCase
+  class FakeAiClient
+    attr_reader :last_call
+
+    def initialize(tool_input)
+      @tool_input = tool_input
+    end
+
+    def chat_with_tools(messages:, tools:, system: nil, max_tokens: 4096)
+      @last_call = { messages: messages, tools: tools, system: system, max_tokens: max_tokens }
+      { name: "extract_recipe", input: @tool_input }
+    end
+  end
+
+  test "generates a full recipe from description" do
+    fake_client = FakeAiClient.new({
+      "title" => "Bacon Wrapped Chicken Thighs",
+      "description" => "Juicy chicken thighs wrapped in crispy bacon",
+      "servings" => 4,
+      "prep_time" => 15,
+      "cook_time" => 35,
+      "ingredients" => [ "4 chicken thighs", "8 slices bacon", "4 oz cream cheese" ],
+      "instructions" => [ "Preheat oven to 400F", "Stuff chicken with cream cheese", "Wrap with bacon", "Bake 35 minutes" ],
+      "calories" => 450.0,
+      "fat" => 32.0,
+      "protein" => 38.0,
+      "carbs" => 1.0,
+      "fiber" => 0.0
+    })
+
+    generator = RecipeImport::AiGenerator.new("bacon wrapped chicken thighs with cream cheese", ai_client: fake_client)
+    result = generator.generate
+
+    assert_equal "Bacon Wrapped Chicken Thighs", result[:title]
+    assert_equal 4, result[:servings]
+    assert_equal 15, result[:prep_time]
+    assert_equal 35, result[:cook_time]
+    assert_equal 3, result[:ingredients].length
+    assert_equal 4, result[:instructions].length
+    assert_equal 1, result[:instructions].first[:step_number]
+    assert_equal "Preheat oven to 400F", result[:instructions].first[:instruction]
+    assert_equal 450.0, result[:nutrition][:calories]
+    assert_equal 32.0, result[:nutrition][:fat]
+  end
+
+  test "includes diet name in system prompt when provided" do
+    fake_client = FakeAiClient.new({
+      "title" => "Keto Pancakes",
+      "ingredients" => [ "almond flour" ],
+      "instructions" => [ "mix and cook" ]
+    })
+
+    RecipeImport::AiGenerator.new("pancakes", diet_name: "Ketogenic (Keto)", ai_client: fake_client).generate
+
+    system = fake_client.last_call[:system]
+    assert_includes system, "Ketogenic (Keto)"
+    assert_includes system, "dietary approach"
+  end
+
+  test "omits diet context when diet_name is nil" do
+    fake_client = FakeAiClient.new({
+      "title" => "Pancakes",
+      "ingredients" => [ "flour" ],
+      "instructions" => [ "cook" ]
+    })
+
+    RecipeImport::AiGenerator.new("pancakes", ai_client: fake_client).generate
+
+    system = fake_client.last_call[:system]
+    assert_not_includes system, "IMPORTANT"
+    assert_not_includes system, "dietary approach"
+  end
+
+  test "sends description in user message" do
+    fake_client = FakeAiClient.new({
+      "title" => "Test",
+      "ingredients" => [ "water" ],
+      "instructions" => [ "boil" ]
+    })
+
+    RecipeImport::AiGenerator.new("spicy tuna bowl", ai_client: fake_client).generate
+
+    message = fake_client.last_call[:messages].first[:content]
+    assert_includes message, "spicy tuna bowl"
+  end
+
+  test "handles missing nutrition gracefully" do
+    fake_client = FakeAiClient.new({
+      "title" => "Simple Dish",
+      "ingredients" => [ "1 egg" ],
+      "instructions" => [ "Cook it" ]
+    })
+
+    result = RecipeImport::AiGenerator.new("egg", ai_client: fake_client).generate
+    assert_nil result[:nutrition]
+  end
+
+  test "normalizes instructions with step numbers" do
+    fake_client = FakeAiClient.new({
+      "title" => "Test",
+      "ingredients" => [ "water" ],
+      "instructions" => [ "Step A", "Step B", "Step C" ]
+    })
+
+    result = RecipeImport::AiGenerator.new("test", ai_client: fake_client).generate
+    assert_equal 1, result[:instructions][0][:step_number]
+    assert_equal 2, result[:instructions][1][:step_number]
+    assert_equal 3, result[:instructions][2][:step_number]
+  end
+
+  test "reuses RECIPE_TOOL from AiExtractor" do
+    assert_equal RecipeImport::AiExtractor::RECIPE_TOOL, RecipeImport::AiGenerator::RECIPE_TOOL
+  end
+end


### PR DESCRIPTION
## Summary

Users can describe a dish in plain text (e.g., "bacon wrapped chicken thighs") and the AI generates a complete recipe with ingredients, instructions, and estimated nutrition data. Supports diet-aware generation using the account's default diet setting.

## Changes

- `RecipeImport::AiGenerator` service — generates full recipes from text descriptions via Claude tool_use, with optional diet context
- `RecipeGenerateJob` — async job inheriting from `AiBaseJob` for background generation
- `quick_entry` controller action and view — text input form with diet badge display
- `start_quick_entry` controller action — validates input, creates `AiTaskStatus`, enqueues job
- Refactored `import_status` failure routing with `FAILURE_PATHS` constant and `failure_path_for` helper
- Cross-links between all three import methods (URL, photo, quick entry)
- Routes: `get :quick_entry`, `post :start_quick_entry`

## Testing

- 7 unit tests for `AiGenerator` (generation, diet context, missing nutrition, step normalization)
- 2 job tests (queue name, inheritance)
- 6 controller integration tests (form rendering, blank input, task creation, failure redirect, diet badge, cross-links)
- All 682 tests pass, Rubocop clean, Brakeman clean

Closes #10