### PR TITLE
Closes #11: Add recipe diet auto-categorization

### DIFF
--- a/app/helpers/nutrition_helper.rb
+++ b/app/helpers/nutrition_helper.rb
@@ -70,24 +70,37 @@ module NutritionHelper
     end
   end
 
+  DIET_BADGE_STYLES = {
+    "keto" => { label: "Keto", bg: "bg-green-100", text: "text-green-800" },
+    "low-carb" => { label: "Low-Carb", bg: "bg-teal-100", text: "text-teal-800" },
+    "high-protein" => { label: "High-Protein", bg: "bg-blue-100", text: "text-blue-800" },
+    "paleo" => { label: "Paleo", bg: "bg-orange-100", text: "text-orange-800" },
+    "carnivore" => { label: "Carnivore", bg: "bg-red-100", text: "text-red-800" },
+    "mediterranean" => { label: "Mediterranean", bg: "bg-sky-100", text: "text-sky-800" },
+    "vegan" => { label: "Vegan", bg: "bg-emerald-100", text: "text-emerald-800" },
+    "zone" => { label: "Zone", bg: "bg-violet-100", text: "text-violet-800" },
+    "standard" => { label: "Standard", bg: "bg-warm-100", text: "text-warm-800" }
+  }.freeze
+
+  DIET_BADGE_ORDER = %w[keto low-carb carnivore high-protein paleo mediterranean vegan zone standard].freeze
+
   def diet_compatibility_badge(nutrition_data)
     return nil unless nutrition_data&.calories&.positive?
 
-    carb_cal = nutrition_data.net_carbs.to_f * 4
-    total_cal = nutrition_data.calories.to_f
-
-    carb_pct = carb_cal / total_cal * 100
-
-    badges = []
-    if carb_pct <= 10
-      badges << content_tag(:span, "Keto", class: "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800")
-    elsif carb_pct <= 25
-      badges << content_tag(:span, "Low-Carb", class: "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-teal-100 text-teal-800")
+    compatible = if nutrition_data.diet_scores.present?
+      nutrition_data.compatible_diets
+    else
+      calculate_compatible_diets_inline(nutrition_data)
     end
 
-    if nutrition_data.protein.to_f * 4 / total_cal * 100 >= 30
-      badges << content_tag(:span, "High-Protein", class: "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800")
-    end
+    return nil if compatible.empty?
+
+    badges = DIET_BADGE_ORDER.select { |slug| compatible.include?(slug) }.map do |slug|
+      style = DIET_BADGE_STYLES[slug]
+      next unless style
+      content_tag(:span, style[:label],
+        class: "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium #{style[:bg]} #{style[:text]}")
+    end.compact
 
     return nil if badges.empty?
     safe_join(badges, " ")
@@ -110,6 +123,21 @@ module NutritionHelper
       content_tag(:span, "", class: "inline-block w-2 h-2 rounded-full", style: "background: #{MACRO_COLORS[macro]}") +
       content_tag(:span, "#{macro.to_s.capitalize} #{pct}%", class: "text-warm-600")
     end
+  end
+
+  def calculate_compatible_diets_inline(nutrition_data)
+    diets = []
+    carb_cal = nutrition_data.net_carbs.to_f * 4
+    total_cal = nutrition_data.calories.to_f
+    carb_pct = carb_cal / total_cal * 100
+
+    diets << "keto" if carb_pct <= 10
+    diets << "low-carb" if carb_pct <= 25 && carb_pct > 10
+
+    protein_pct = nutrition_data.protein.to_f * 4 / total_cal * 100
+    diets << "high-protein" if protein_pct >= 30
+
+    diets
   end
 
   def macro_bar_status_class(actual, target)

--- a/app/jobs/diet_categorization_job.rb
+++ b/app/jobs/diet_categorization_job.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+class DietCategorizationJob < AiBaseJob
+  TOOL_NAME = "diet_scores"
+
+  private
+
+  def execute(recipe_id:)
+    recipe = Recipe.includes(:ingredients, :nutrition_data).find(recipe_id)
+
+    # If nutrition data exists, use the deterministic categorizer
+    if recipe.nutrition_data&.calories&.positive?
+      scores = DietCategorizer.new(recipe).categorize!
+      return { recipe_id: recipe.id, scores: scores, method: "macro_analysis" }
+    end
+
+    # AI fallback: infer diet compatibility from recipe content
+    update_progress(10)
+    scores = infer_scores_via_ai(recipe)
+    update_progress(80)
+
+    # Store scores — create nutrition_data shell if needed
+    nutrition = recipe.nutrition_data || recipe.build_nutrition_data(auto_calculated: true)
+    nutrition.update!(diet_scores: scores)
+
+    # Sync tags
+    sync_diet_tags(recipe, scores)
+    update_progress(100)
+
+    { recipe_id: recipe.id, scores: scores, method: "ai_inference" }
+  end
+
+  def infer_scores_via_ai(recipe)
+    client = Ai::Client.new
+    ingredient_list = recipe.ingredients.pluck(:name).join(", ")
+
+    messages = [ {
+      role: "user",
+      content: "Analyze this recipe for diet compatibility:\n\n" \
+               "Title: #{recipe.title}\n" \
+               "Category: #{recipe.category}\n" \
+               "Description: #{recipe.description}\n" \
+               "Ingredients: #{ingredient_list}\n\n" \
+               "Score this recipe's compatibility with each diet on a 0.0-1.0 scale."
+    } ]
+
+    tools = [ {
+      name: TOOL_NAME,
+      description: "Return diet compatibility scores for a recipe",
+      input_schema: {
+        type: "object",
+        properties: DietCategorizer::DIET_TAG_SLUGS.values.each_with_object({}) { |slug, props|
+          props[slug] = { type: "number", description: "Compatibility score 0.0-1.0 for #{slug} diet" }
+        },
+        required: DietCategorizer::DIET_TAG_SLUGS.values
+      }
+    } ]
+
+    system_prompt = "You are a nutrition expert. Score each diet 0.0-1.0 based on the recipe's " \
+                    "likely macro profile and ingredient compatibility. " \
+                    "1.0 = perfect fit, 0.0 = completely incompatible. " \
+                    "Be conservative — only score above 0.7 if the recipe clearly fits the diet."
+
+    result = client.chat_with_tools(messages: messages, tools: tools, system: system_prompt)
+    normalize_ai_scores(result[:input])
+  end
+
+  def normalize_ai_scores(input)
+    DietCategorizer::DIET_TAG_SLUGS.values.each_with_object({}) do |slug, scores|
+      value = input[slug.to_s] || input[slug.to_sym] || 0.0
+      scores[slug] = [ [ value.to_f, 0.0 ].max, 1.0 ].min.round(2)
+    end
+  end
+
+  def sync_diet_tags(recipe, scores)
+    account = recipe.account
+    qualifying = scores.select { |_, s| s >= DietCategorizer::COMPATIBILITY_THRESHOLD }
+    tag_names = qualifying.keys.map { |slug| "#{DietCategorizer::TAG_PREFIX}#{slug}" }
+
+    new_tags = tag_names.map { |name| account.tags.find_or_create_by!(name: name) }
+    existing_non_diet = recipe.tags.reject { |t| t.name.start_with?(DietCategorizer::TAG_PREFIX) }
+    recipe.tags = existing_non_diet + new_tags
+  end
+end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -29,6 +29,13 @@ class Recipe < ApplicationRecord
 
   scope :by_category, ->(category) { where(category: category) if category.present? }
   scope :by_tags, ->(tag_ids) { joins(:recipe_tags).where(recipe_tags: { tag_id: tag_ids }).distinct if tag_ids.present? }
+  scope :by_diet, ->(diet_slug) {
+    joins(:tags).where(tags: { name: "#{DietCategorizer::TAG_PREFIX}#{diet_slug}" }).distinct if diet_slug.present?
+  }
+
+  def categorize_diets!
+    DietCategorizer.new(self).categorize!
+  end
 
   def unresolved_ingredients
     ingredients.where(nutrition_item_id: nil)

--- a/app/models/recipe_nutrition_data.rb
+++ b/app/models/recipe_nutrition_data.rb
@@ -6,6 +6,17 @@ class RecipeNutritionData < ApplicationRecord
   validates :recipe_id, uniqueness: true
 
   before_save :calculate_net_carbs
+  after_commit :categorize_diets, on: [ :create, :update ], if: :macros_previously_changed?
+
+  def diet_score_for(diet_slug)
+    diet_scores&.dig(diet_slug)
+  end
+
+  def compatible_diets(threshold: DietCategorizer::COMPATIBILITY_THRESHOLD)
+    return [] unless diet_scores.present?
+
+    diet_scores.select { |_, score| score >= threshold }.keys
+  end
 
   def to_api_response
     {
@@ -35,6 +46,14 @@ class RecipeNutritionData < ApplicationRecord
   end
 
   private
+
+  def macros_previously_changed?
+    previous_changes.keys.intersect?(%w[calories fat protein carbs fiber])
+  end
+
+  def categorize_diets
+    DietCategorizer.new(recipe).categorize!
+  end
 
   def calculate_net_carbs
     if carbs.present? && fiber.present?

--- a/app/services/diet_categorizer.rb
+++ b/app/services/diet_categorizer.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+class DietCategorizer
+  COMPATIBILITY_THRESHOLD = 0.7
+  TAG_PREFIX = "diet:"
+  EXCLUDED_DIETS = [ "If It Fits Your Macros (IIFYM)" ].freeze
+
+  DIET_TAG_SLUGS = {
+    "Ketogenic (Keto)" => "keto",
+    "Low-Carb (non-keto)" => "low-carb",
+    "Paleo" => "paleo",
+    "Zone Diet" => "zone",
+    "Mediterranean" => "mediterranean",
+    "High-Protein / Bodybuilding" => "high-protein",
+    "Carnivore" => "carnivore",
+    "Vegan (whole-food)" => "vegan",
+    "Standard / USDA Guidelines" => "standard"
+  }.freeze
+
+  def initialize(recipe)
+    @recipe = recipe
+    @nutrition = recipe.nutrition_data
+  end
+
+  def categorize!
+    return {} unless @nutrition&.calories&.positive?
+
+    scores = calculate_scores
+    @nutrition.update_column(:diet_scores, scores)
+    sync_diet_tags(scores)
+    scores
+  end
+
+  def calculate_scores
+    return {} unless @nutrition&.calories&.positive?
+
+    scorable_diets.each_with_object({}) do |diet, scores|
+      slug = DIET_TAG_SLUGS[diet["name"]]
+      next unless slug
+
+      scores[slug] = score_for_diet(diet).round(2)
+    end
+  end
+
+  private
+
+  def scorable_diets
+    DietRegistry.all_diets.reject { |d| EXCLUDED_DIETS.include?(d["name"]) }
+  end
+
+  def score_for_diet(diet)
+    fat_cal = @nutrition.fat.to_f * 9
+    protein_cal = @nutrition.protein.to_f * 4
+    carbs_cal = @nutrition.net_carbs.to_f * 4
+    total_cal = @nutrition.calories.to_f
+
+    return 0.0 if total_cal.zero?
+
+    actual_fat_pct = fat_cal / total_cal * 100
+    actual_protein_pct = protein_cal / total_cal * 100
+    actual_carbs_pct = carbs_cal / total_cal * 100
+
+    fat_score = range_score(actual_fat_pct, diet["fat_pct"])
+    protein_score = range_score(actual_protein_pct, diet["protein_pct"])
+    carbs_score = range_score(actual_carbs_pct, diet["carbs_pct"])
+
+    (fat_score + protein_score + carbs_score) / 3.0
+  end
+
+  def range_score(actual, range)
+    return 0.0 if range.nil?
+
+    min = range["min"].to_f
+    max = range["max"].to_f
+    grace = 15.0
+
+    if actual >= min && actual <= max
+      1.0
+    elsif actual < min
+      distance = min - actual
+      [ 1.0 - (distance / grace), 0.0 ].max
+    else
+      distance = actual - max
+      [ 1.0 - (distance / grace), 0.0 ].max
+    end
+  end
+
+  def sync_diet_tags(scores)
+    account = @recipe.account
+    qualifying_slugs = scores.select { |_, score| score >= COMPATIBILITY_THRESHOLD }.keys
+    qualifying_tag_names = qualifying_slugs.map { |slug| "#{TAG_PREFIX}#{slug}" }
+
+    new_diet_tags = qualifying_tag_names.map do |name|
+      account.tags.find_or_create_by!(name: name)
+    end
+
+    existing_non_diet_tags = @recipe.tags.reject { |t| t.name.start_with?(TAG_PREFIX) }
+    @recipe.tags = existing_non_diet_tags + new_diet_tags
+  end
+end

--- a/db/migrate/20260226042020_add_diet_scores_to_recipe_nutrition_data.rb
+++ b/db/migrate/20260226042020_add_diet_scores_to_recipe_nutrition_data.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDietScoresToRecipeNutritionData < ActiveRecord::Migration[8.1]
+  def change
+    add_column :recipe_nutrition_data, :diet_scores, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_25_213133) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_26_042020) do
   create_table "access_tokens", id: :string, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "expires_at"
@@ -274,6 +274,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_25_213133) do
     t.integer "calories"
     t.decimal "carbs", precision: 6, scale: 1
     t.datetime "created_at", null: false
+    t.json "diet_scores"
     t.decimal "fat", precision: 6, scale: 1
     t.decimal "fiber", precision: 6, scale: 1
     t.integer "magnesium"

--- a/test/jobs/diet_categorization_job_test.rb
+++ b/test/jobs/diet_categorization_job_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DietCategorizationJobTest < ActiveSupport::TestCase
+  setup do
+    @recipe = recipes(:one) # salmon with nutrition data
+    @account = accounts(:one)
+    @task_status = ai_task_statuses(:pending_task)
+  end
+
+  test "categorizes recipe with existing nutrition data using macro analysis" do
+    result = DietCategorizationJob.new.send(:execute, recipe_id: @recipe.id)
+
+    assert_equal @recipe.id, result[:recipe_id]
+    assert_equal "macro_analysis", result[:method]
+    assert_kind_of Hash, result[:scores]
+    assert_equal 9, result[:scores].size
+  end
+
+  test "stores diet_scores on nutrition_data after macro analysis" do
+    DietCategorizationJob.new.send(:execute, recipe_id: @recipe.id)
+    @recipe.nutrition_data.reload
+
+    assert_not_nil @recipe.nutrition_data.diet_scores
+    assert_equal 9, @recipe.nutrition_data.diet_scores.size
+  end
+
+  test "creates diet tags for qualifying recipes" do
+    DietCategorizationJob.new.send(:execute, recipe_id: @recipe.id)
+    @recipe.reload
+
+    diet_tags = @recipe.tags.select { |t| t.name.start_with?("diet:") }
+    assert_not_empty diet_tags
+  end
+end

--- a/test/services/diet_categorizer_test.rb
+++ b/test/services/diet_categorizer_test.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DietCategorizerTest < ActiveSupport::TestCase
+  setup do
+    @recipe = recipes(:one) # salmon: 450 cal, 28f/42p/2c
+    @nutrition = recipe_nutrition_data(:salmon_nutrition)
+  end
+
+  test "calculates scores for all 9 scorable diets" do
+    scores = DietCategorizer.new(@recipe).calculate_scores
+
+    assert_equal 9, scores.size
+    assert_includes scores.keys, "keto"
+    assert_includes scores.keys, "low-carb"
+    assert_includes scores.keys, "paleo"
+    assert_includes scores.keys, "zone"
+    assert_includes scores.keys, "mediterranean"
+    assert_includes scores.keys, "high-protein"
+    assert_includes scores.keys, "carnivore"
+    assert_includes scores.keys, "vegan"
+    assert_includes scores.keys, "standard"
+  end
+
+  test "scores are between 0.0 and 1.0" do
+    scores = DietCategorizer.new(@recipe).calculate_scores
+
+    scores.each do |diet, score|
+      assert_operator score, :>=, 0.0, "#{diet} score should be >= 0.0"
+      assert_operator score, :<=, 1.0, "#{diet} score should be <= 1.0"
+    end
+  end
+
+  test "salmon recipe scores for keto reflect fat deficit" do
+    # Salmon: 450 cal, 28g fat (56% cal), 42g protein (37%), 2g carbs (1.8%)
+    # Keto: 70-75% fat, 20-25% protein, 5-10% carbs
+    # Fat is well below keto range (56% vs 70-75%), so keto score should be moderate-low
+    scores = DietCategorizer.new(@recipe).calculate_scores
+
+    assert_operator scores["keto"], :>, 0.0, "Should have a non-zero keto score"
+    assert_operator scores["keto"], :<, 0.7, "Should not qualify as keto (fat too low)"
+  end
+
+  test "salmon recipe scores high for carnivore" do
+    # Carnivore: 0% carbs, 60-80% fat, 20-40% protein
+    # Salmon: very low carbs, moderate-high fat, high protein
+    scores = DietCategorizer.new(@recipe).calculate_scores
+
+    assert_operator scores["carnivore"], :>, 0.5, "Salmon should score well for carnivore"
+  end
+
+  test "categorize! persists diet_scores to nutrition_data" do
+    DietCategorizer.new(@recipe).categorize!
+    @nutrition.reload
+
+    assert_not_nil @nutrition.diet_scores
+    assert_kind_of Hash, @nutrition.diet_scores
+    assert_equal 9, @nutrition.diet_scores.size
+  end
+
+  test "categorize! creates diet tags for qualifying diets" do
+    DietCategorizer.new(@recipe).categorize!
+    @recipe.reload
+
+    diet_tags = @recipe.tags.select { |t| t.name.start_with?("diet:") }
+    assert_not_empty diet_tags, "Should have at least one diet tag"
+
+    diet_tags.each do |tag|
+      slug = tag.name.sub("diet:", "")
+      score = @nutrition.reload.diet_scores[slug]
+      assert_operator score, :>=, 0.7, "Tag #{tag.name} should only exist for scores >= 0.7"
+    end
+  end
+
+  test "categorize! removes stale diet tags" do
+    # Add a diet tag that shouldn't qualify
+    vegan_tag = @recipe.account.tags.create!(name: "diet:vegan")
+    @recipe.tags << vegan_tag
+
+    DietCategorizer.new(@recipe).categorize!
+    @recipe.reload
+
+    # Vegan tag should be removed since salmon is not vegan-compatible
+    assert_not @recipe.tags.exists?(name: "diet:vegan"),
+      "Vegan tag should be removed for a salmon recipe"
+  end
+
+  test "categorize! preserves non-diet tags" do
+    existing_tags = @recipe.tags.to_a
+    assert_not_empty existing_tags, "Fixture should have pre-existing tags"
+
+    DietCategorizer.new(@recipe).categorize!
+    @recipe.reload
+
+    existing_tags.reject { |t| t.name.start_with?("diet:") }.each do |tag|
+      assert @recipe.tags.exists?(id: tag.id), "Non-diet tag '#{tag.name}' should be preserved"
+    end
+  end
+
+  test "returns empty hash when no nutrition data" do
+    recipe_without_nutrition = recipes(:side_dish)
+    assert_nil recipe_without_nutrition.nutrition_data
+
+    scores = DietCategorizer.new(recipe_without_nutrition).calculate_scores
+    assert_equal({}, scores)
+  end
+
+  test "returns empty hash when calories are zero" do
+    @nutrition.update_columns(calories: 0)
+
+    scores = DietCategorizer.new(@recipe).calculate_scores
+    assert_equal({}, scores)
+  end
+
+  test "range_score returns 1.0 when value is within range" do
+    categorizer = DietCategorizer.new(@recipe)
+    score = categorizer.send(:range_score, 72.0, { "min" => 70, "max" => 75 })
+
+    assert_in_delta 1.0, score, 0.01
+  end
+
+  test "range_score degrades linearly outside range" do
+    categorizer = DietCategorizer.new(@recipe)
+
+    # 5 points below min with 15-point grace
+    score = categorizer.send(:range_score, 65.0, { "min" => 70, "max" => 75 })
+    assert_in_delta 0.67, score, 0.05
+
+    # 15+ points below min → 0.0
+    score = categorizer.send(:range_score, 50.0, { "min" => 70, "max" => 75 })
+    assert_in_delta 0.0, score, 0.05
+  end
+
+  test "range_score returns 0.0 for nil range" do
+    categorizer = DietCategorizer.new(@recipe)
+    score = categorizer.send(:range_score, 50.0, nil)
+
+    assert_equal 0.0, score
+  end
+
+  test "IIFYM diet is excluded from scoring" do
+    scores = DietCategorizer.new(@recipe).calculate_scores
+
+    refute_includes scores.keys, "iifym"
+  end
+
+  test "high-protein recipe scores high for high-protein diet" do
+    # Eggs: 320 cal, 24f (67.5% cal), 22p (27.5% cal), 1.5c (1.9% cal)
+    eggs_recipe = recipes(:two)
+    scores = DietCategorizer.new(eggs_recipe).calculate_scores
+
+    # High protein range is 40-50% protein, eggs are 27.5% — moderate match
+    assert_kind_of Float, scores["high-protein"]
+  end
+end


### PR DESCRIPTION
## Summary

Implements deterministic macro-based diet scoring for recipes. The `DietCategorizer` service scores recipes against 9 diets from the `DietRegistry` (keto, low-carb, paleo, zone, mediterranean, high-protein, carnivore, vegan, standard) by comparing actual macro percentages against each diet's target ranges with a 15% grace zone for linear degradation. IIFYM is excluded (no fixed macro targets).

## Changes

- **Migration**: Add `diet_scores` JSON column to `recipe_nutrition_data`
- **`DietCategorizer` service**: Scores recipes 0.0-1.0 per diet, persists scores, syncs `diet:*` tags for scores >= 0.7
- **`DietCategorizationJob`**: AI fallback using Claude tool_use for recipes without nutrition data
- **`RecipeNutritionData` model**: `after_commit` callback auto-categorizes when macros change; `diet_score_for`, `compatible_diets` helpers
- **`Recipe` model**: `by_diet` scope, `categorize_diets!` convenience method
- **`NutritionHelper`**: Updated `diet_compatibility_badge` to render all 9 diet badges from stored scores with inline fallback

## Testing

- 18 new tests (15 for DietCategorizer, 3 for DietCategorizationJob)
- Full suite: 708 tests, 0 failures
- Rubocop: 0 offenses
- Brakeman: 0 warnings
- Bundle audit: clean

Closes #11