### PR TITLE
Reduce AI meal plan generation API costs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Controllers under `app/controllers/accounts/api/v1/` inherit from `ActionControl
 
 ### AI Service Layer
 
-`Ai::Client` (`app/services/ai/client.rb`) wraps the Anthropic Claude API via the `anthropic` gem. Configured in `config/initializers/ai.rb` (default model: `claude-sonnet-4-20250514`).
+`Ai::Client` (`app/services/ai/client.rb`) wraps the Anthropic Claude API via the `anthropic` gem. Configured in `config/initializers/ai.rb` (default model: `claude-sonnet-4-20250514`, meal planning model: `claude-haiku-4-5-20251001`).
 
 **Methods:**
 - `chat(messages:, system:, max_tokens:)` — text completion
@@ -67,6 +67,16 @@ Controllers under `app/controllers/accounts/api/v1/` inherit from `ActionControl
 **Credentials:** `Rails.application.credentials.dig(:ai, :anthropic, :api_key)`
 
 **Error handling:** Retries 3× with exponential backoff (1s/2s/4s) on rate limits, server errors, and timeouts. Custom exceptions: `Ai::Client::ApiError`, `RateLimitError`, `TimeoutError`, `AuthenticationError`.
+
+### AI Meal Plan Generation
+
+`MealPlanGenerator` (`app/services/meal_plan_generator.rb`) orchestrates AI-powered meal plan creation using Haiku 4.5 for cost efficiency. Uses prompt caching (`cache_control: { type: "ephemeral" }`) on the static system prompt. Recipes are sent as integer indices (not UUIDs) to reduce token costs, with `@index_to_id` mapping indices back to UUIDs when populating the plan.
+
+`RecipeSelector` (`app/services/recipe_selector.rb`) pre-filters and ranks recipes before sending to the AI:
+- **Hard exclusion**: Removes recipes from recent past meal plans (adaptive N based on catalog size). Skipped when catalog < 20 recipes.
+- **Soft scoring** (5 weighted factors): usage frequency (30%), recency decay (25%), diet compatibility (20%), category fit (15%), newness bonus (10%)
+- **Category-proportional selection**: Ensures minimum representation (`MIN_PER_CATEGORY = 3`) per active meal type category
+- Accepts `current_date:` override for deterministic testing
 
 ### AI Background Jobs
 

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -95,9 +95,7 @@ class Recipe < ApplicationRecord
       prep_time: prep_time,
       cook_time: cook_time,
       nutrition_per_serving: nutrition_data&.to_meal_planning_response,
-      tags: tags.pluck(:name),
-      ingredients_summary: ingredients_summary,
-      url: "/#{account.external_account_id}/recipes/#{id}"
+      tags: tags.pluck(:name)
     }
   end
 end

--- a/app/models/recipe_nutrition_data.rb
+++ b/app/models/recipe_nutrition_data.rb
@@ -37,11 +37,7 @@ class RecipeNutritionData < ApplicationRecord
       calories: calories,
       fat_g: fat&.to_f,
       protein_g: protein&.to_f,
-      net_carbs_g: net_carbs&.to_f,
-      fiber_g: fiber&.to_f,
-      sodium_mg: sodium,
-      potassium_mg: potassium,
-      magnesium_mg: magnesium
+      net_carbs_g: net_carbs&.to_f
     }
   end
 

--- a/app/services/meal_plan_generator.rb
+++ b/app/services/meal_plan_generator.rb
@@ -14,16 +14,31 @@ class MealPlanGenerator
 
   MIN_RECIPES_REQUIRED = 3
 
+  SYSTEM_RULES = <<~RULES.freeze
+    You are a meal planning assistant for a family-oriented meal planning app.
+    Your job is to create an optimized weekly meal plan that respects dietary requirements,
+    macro targets, and user preferences.
+
+    RULES:
+    - Only use recipe IDs from the provided catalog
+    - Each meal assignment should have exactly one recipe
+    - Aim for variety: minimize recipe repetition across the week
+    - Match recipes to appropriate meal types (breakfast recipes for breakfast, etc.)
+    - Consider prep/cook time when assigning meals
+    - Target each participant's daily calorie goals by choosing appropriate recipes
+    - These recipes have been pre-selected for variety and dietary fit. Use them all if possible to maximize rotation.
+  RULES
+
   def initialize(meal_plan, preferences: [], special_requests: nil, ai_client: nil)
     @meal_plan = meal_plan
     @account = meal_plan.account
     @preferences = Array(preferences)
     @special_requests = special_requests.presence
-    @ai_client = ai_client || Ai::Client.new
+    @ai_client = ai_client || Ai::Client.new(model: Ai.meal_planning_model)
   end
 
   def generate(&progress_callback)
-    recipes = fetch_eligible_recipes
+    recipes = select_recipes
     validate_recipe_catalog!(recipes)
 
     report_progress(progress_callback, 10)
@@ -50,12 +65,16 @@ class MealPlanGenerator
 
   private
 
-  def fetch_eligible_recipes
-    @account.recipes
-      .joins(:nutrition_data)
-      .includes(:nutrition_data, :tags)
-      .where.not(recipe_nutrition_data: { calories: nil })
-      .to_a
+  def select_recipes
+    meal_types = active_meal_types
+    participant_diets = @meal_plan.dietary_profiles.pluck(:diet_name)
+
+    selector = RecipeSelector.new(
+      @account, @meal_plan,
+      meal_types: meal_types,
+      participant_diets: participant_diets
+    )
+    selector.select
   end
 
   def validate_recipe_catalog!(recipes)
@@ -105,7 +124,12 @@ class MealPlanGenerator
   end
 
   def call_ai(recipes, constraints)
-    recipe_catalog = recipes.map(&:to_meal_planning_response)
+    @index_to_id = {}
+    recipe_catalog = recipes.each_with_index.map do |recipe, idx|
+      index = idx + 1
+      @index_to_id[index] = recipe.id
+      recipe_to_indexed_hash(recipe, index)
+    end
 
     system_prompt = build_system_prompt(constraints)
     user_message = build_user_message(recipe_catalog, constraints)
@@ -114,7 +138,7 @@ class MealPlanGenerator
       messages: [ { role: "user", content: user_message } ],
       tools: [ meal_plan_tool_definition ],
       system: system_prompt,
-      max_tokens: 8192
+      max_tokens: 4096
     )
 
     unless result[:name] == "assign_meals"
@@ -124,44 +148,50 @@ class MealPlanGenerator
     result[:input]
   end
 
-  def build_system_prompt(constraints)
-    prompt = <<~SYSTEM
-      You are a meal planning assistant for a family-oriented meal planning app.
-      Your job is to create an optimized weekly meal plan that respects dietary requirements,
-      macro targets, and user preferences.
+  def recipe_to_indexed_hash(recipe, index)
+    data = recipe.to_meal_planning_response
+    data[:index] = index
+    data
+  end
 
-      RULES:
-      - Only use recipe IDs from the provided catalog
-      - Each meal assignment should have exactly one recipe
-      - Aim for variety: minimize recipe repetition across the week
-      - Match recipes to appropriate meal types (breakfast recipes for breakfast, etc.)
-      - Consider prep/cook time when assigning meals
-      - Target each participant's daily calorie goals by choosing appropriate recipes
-    SYSTEM
+  def build_system_prompt(constraints)
+    # Static rules get cache_control for prompt caching; dynamic context is appended as a separate block
+    blocks = [
+      { type: "text", text: SYSTEM_RULES, cache_control: { type: "ephemeral" } }
+    ]
+
+    dynamic = build_dynamic_context(constraints)
+    blocks << { type: "text", text: dynamic } if dynamic.present?
+
+    blocks
+  end
+
+  def build_dynamic_context(constraints)
+    parts = []
 
     if constraints[:dietary_profiles]&.any?
-      prompt += "\nPARTICIPANT DIETARY PROFILES:\n"
+      parts << "PARTICIPANT DIETARY PROFILES:"
       constraints[:dietary_profiles].each do |profile|
-        prompt += "- #{profile[:name]}: #{profile[:diet] || 'No specific diet'}, "
-        prompt += "#{profile[:daily_calories] || 'no'} daily calorie target"
+        line = "- #{profile[:name]}: #{profile[:diet] || 'No specific diet'}, "
+        line += "#{profile[:daily_calories] || 'no'} daily calorie target"
         if profile[:macro_targets]
           mt = profile[:macro_targets]
-          prompt += ", macros: #{mt[:fat_g]}g fat, #{mt[:protein_g]}g protein, #{mt[:carbs_g]}g carbs" if mt[:fat_g]
+          line += ", macros: #{mt[:fat_g]}g fat, #{mt[:protein_g]}g protein, #{mt[:carbs_g]}g carbs" if mt[:fat_g]
         end
-        prompt += "\n"
+        parts << line
       end
     end
 
     if constraints[:preferences].any?
-      prompt += "\nUSER PREFERENCES:\n"
-      constraints[:preferences].each { |p| prompt += "- #{p}\n" }
+      parts << "\nUSER PREFERENCES:"
+      constraints[:preferences].each { |p| parts << "- #{p}" }
     end
 
     if constraints[:special_requests]
-      prompt += "\nSPECIAL REQUESTS:\n#{constraints[:special_requests]}\n"
+      parts << "\nSPECIAL REQUESTS:\n#{constraints[:special_requests]}"
     end
 
-    prompt
+    parts.join("\n")
   end
 
   def build_user_message(recipe_catalog, constraints)
@@ -176,17 +206,17 @@ class MealPlanGenerator
 
       #{recipe_catalog.map { |r| format_recipe_for_prompt(r) }.join("\n\n")}
 
-      Please assign one recipe to each meal slot for each day using the assign_meals tool.
+      Assign one recipe to each meal slot for each day using the assign_meals tool.
       Choose recipes that best fit the dietary requirements and optimize for variety and nutrition balance.
     USER
   end
 
   def format_recipe_for_prompt(recipe)
     nutrition = recipe[:nutrition_per_serving]
-    parts = [ "ID: #{recipe[:id]} | #{recipe[:title]} (#{recipe[:category]})" ]
+    parts = [ "##{recipe[:index]} #{recipe[:title]} (#{recipe[:category]})" ]
     parts << "  Servings: #{recipe[:servings]}, Prep: #{recipe[:prep_time] || '?'}min, Cook: #{recipe[:cook_time] || '?'}min"
     if nutrition
-      parts << "  Per serving: #{nutrition[:calories]} cal, #{nutrition[:fat_g]}g fat, #{nutrition[:protein_g]}g protein, #{nutrition[:net_carbs_g]}g net carbs"
+      parts << "  #{nutrition[:calories]} cal, #{nutrition[:fat_g]}g fat, #{nutrition[:protein_g]}g protein, #{nutrition[:net_carbs_g]}g net carbs"
     end
     parts << "  Tags: #{recipe[:tags].join(', ')}" if recipe[:tags].any?
     parts.join("\n")
@@ -195,14 +225,13 @@ class MealPlanGenerator
   def meal_plan_tool_definition
     {
       name: "assign_meals",
-      description: "Assign recipes to each meal slot in the meal plan. Each day should have meals assigned based on the requested meal types.",
+      description: "Assign recipes to each meal slot in the meal plan.",
       input_schema: {
         type: "object",
         required: [ "days" ],
         properties: {
           days: {
             type: "array",
-            description: "Array of day assignments",
             items: {
               type: "object",
               required: [ "day_number", "meals" ],
@@ -213,33 +242,23 @@ class MealPlanGenerator
                 },
                 meals: {
                   type: "array",
-                  description: "Meals assigned to this day",
                   items: {
                     type: "object",
                     required: [ "meal_type", "recipe_id" ],
                     properties: {
                       meal_type: {
                         type: "string",
-                        enum: %w[breakfast lunch dinner snack],
-                        description: "The type of meal"
+                        enum: %w[breakfast lunch dinner snack]
                       },
                       recipe_id: {
-                        type: "string",
-                        description: "The ID of the recipe to assign"
-                      },
-                      servings: {
-                        type: "number",
-                        description: "Number of base recipe servings (default 1.0)"
+                        type: "integer",
+                        description: "The recipe index number from the catalog"
                       }
                     }
                   }
                 }
               }
             }
-          },
-          reasoning: {
-            type: "string",
-            description: "Brief explanation of the meal plan choices and optimization strategy"
           }
         }
       }
@@ -256,20 +275,28 @@ class MealPlanGenerator
       next unless day
 
       Array(day_data["meals"]).each do |meal_data|
-        recipe = recipe_lookup[meal_data["recipe_id"].to_s]
+        recipe_id = resolve_recipe_id(meal_data["recipe_id"])
+        recipe = recipe_lookup[recipe_id]
         next unless recipe
 
         meal_type = meal_data["meal_type"]
         next unless MealPlanMeal.meal_types.key?(meal_type)
 
-        servings = (meal_data["servings"] || 1.0).to_f.clamp(0.25, 10.0)
-
         day.meals.create!(
           recipe: recipe,
           meal_type: meal_type,
-          servings: servings
+          servings: 1.0
         )
       end
+    end
+  end
+
+  def resolve_recipe_id(raw_id)
+    # AI returns integer indices; map back to UUIDs
+    if raw_id.is_a?(Integer) || (raw_id.is_a?(String) && raw_id.match?(/\A\d+\z/))
+      @index_to_id[raw_id.to_i]
+    else
+      raw_id.to_s
     end
   end
 

--- a/app/services/recipe_selector.rb
+++ b/app/services/recipe_selector.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+class RecipeSelector
+  SCORE_WEIGHTS = {
+    usage_frequency: 0.30,
+    recency_decay: 0.25,
+    diet_compatibility: 0.20,
+    category_fit: 0.15,
+    newness_bonus: 0.10
+  }.freeze
+
+  DEFAULT_LIMIT = 50
+  MIN_PER_CATEGORY = 3
+  SMALL_CATALOG_THRESHOLD = 20
+  NEWNESS_WINDOW = 14.days
+  RECENCY_DECAY_WEEKS = 4
+
+  def initialize(account, meal_plan, meal_types:, participant_diets: [], current_date: Date.current)
+    @account = account
+    @meal_plan = meal_plan
+    @meal_types = meal_types
+    @participant_diets = participant_diets
+    @current_date = current_date
+  end
+
+  def select(limit: DEFAULT_LIMIT)
+    candidates = fetch_eligible_recipes
+    candidates = hard_exclude_recent(candidates)
+
+    return candidates if candidates.size <= limit
+
+    scored = score_recipes(candidates)
+    pick_by_category(scored, limit: limit)
+  end
+
+  private
+
+  def fetch_eligible_recipes
+    @account.recipes
+      .joins(:nutrition_data)
+      .includes(:nutrition_data, :tags)
+      .where.not(recipe_nutrition_data: { calories: nil })
+      .to_a
+  end
+
+  def hard_exclude_recent(candidates)
+    recent_recipe_ids = recently_used_recipe_ids(candidates.size)
+    return candidates if recent_recipe_ids.empty?
+
+    filtered = candidates.reject { |r| recent_recipe_ids.include?(r.id) }
+
+    # If exclusion would drop below minimum viable, return all candidates
+    filtered.size >= MealPlanGenerator::MIN_RECIPES_REQUIRED ? filtered : candidates
+  end
+
+  def recently_used_recipe_ids(catalog_size)
+    return [] if catalog_size < SMALL_CATALOG_THRESHOLD
+
+    meals_per_plan = @meal_types.size * (@meal_plan.duration_days || 7)
+    plans_to_exclude = [ 3, catalog_size / [ meals_per_plan, 1 ].max ].min
+    plans_to_exclude = [ plans_to_exclude, 1 ].max
+
+    recent_plans = @account.meal_plans
+      .where.not(id: @meal_plan.id)
+      .where("end_date < ?", @current_date)
+      .order(start_date: :desc)
+      .limit(plans_to_exclude)
+
+    MealPlanMeal
+      .joins(meal_plan_day: :meal_plan)
+      .where(meal_plan_days: { meal_plan_id: recent_plans.select(:id) })
+      .distinct
+      .pluck(:recipe_id)
+  end
+
+  def score_recipes(candidates)
+    usage_counts = recipe_usage_counts
+    last_used_dates = recipe_last_used_dates
+    diet_slugs = participant_diet_slugs
+
+    candidates.map do |recipe|
+      score = 0.0
+      score += SCORE_WEIGHTS[:usage_frequency] * usage_frequency_score(recipe, usage_counts)
+      score += SCORE_WEIGHTS[:recency_decay] * recency_decay_score(recipe, last_used_dates)
+      score += SCORE_WEIGHTS[:diet_compatibility] * diet_compatibility_score(recipe, diet_slugs)
+      score += SCORE_WEIGHTS[:category_fit] * category_fit_score(recipe)
+      score += SCORE_WEIGHTS[:newness_bonus] * newness_score(recipe)
+
+      { recipe: recipe, score: score }
+    end
+  end
+
+  def pick_by_category(scored, limit:)
+    # Allocate slots proportionally across active meal-type categories
+    category_map = map_meal_types_to_categories
+    per_category = [ limit / [ category_map.size, 1 ].max, MIN_PER_CATEGORY ].max
+
+    selected = Set.new
+    remaining = scored.sort_by { |s| -s[:score] }
+
+    # First pass: fill each category up to its allocation
+    category_map.each do |category|
+      category_recipes = remaining.select { |s| s[:recipe].category == category }
+      picks = category_recipes.first(per_category)
+      picks.each { |s| selected.add(s[:recipe].id) }
+    end
+
+    # Second pass: fill remaining slots with highest-scoring uncategorized recipes
+    if selected.size < limit
+      remaining.each do |s|
+        break if selected.size >= limit
+        selected.add(s[:recipe].id)
+      end
+    end
+
+    scored.select { |s| selected.include?(s[:recipe].id) }
+      .sort_by { |s| -s[:score] }
+      .map { |s| s[:recipe] }
+  end
+
+  # --- Scoring functions (each returns 0.0–100.0) ---
+
+  def usage_frequency_score(recipe, usage_counts)
+    count = usage_counts[recipe.id] || 0
+    return 0.0 if count.zero?
+
+    max_count = usage_counts.values.max || 1
+    (count.to_f / max_count * 100.0)
+  end
+
+  def recency_decay_score(recipe, last_used_dates)
+    last_used = last_used_dates[recipe.id]
+    return 80.0 unless last_used # Never used — good candidate
+
+    weeks_ago = ((@current_date - last_used).to_f / 7).ceil
+    if weeks_ago <= RECENCY_DECAY_WEEKS
+      # Recently used — penalize with exponential decay
+      (weeks_ago.to_f / RECENCY_DECAY_WEEKS * 60.0)
+    else
+      # Not used recently — full score
+      100.0
+    end
+  end
+
+  def diet_compatibility_score(recipe, diet_slugs)
+    return 50.0 if diet_slugs.empty? # No dietary context — neutral score
+
+    scores = recipe.nutrition_data&.diet_scores
+    return 50.0 unless scores.present?
+
+    avg = diet_slugs.sum { |slug| (scores[slug] || 0.0).to_f } / diet_slugs.size
+    (avg * 100.0)
+  end
+
+  def category_fit_score(recipe)
+    matching_categories = map_meal_types_to_categories
+    matching_categories.include?(recipe.category) ? 100.0 : 20.0
+  end
+
+  def newness_score(recipe)
+    days_old = (@current_date - recipe.created_at.to_date).to_i
+    days_old <= NEWNESS_WINDOW.in_days.to_i ? 100.0 : 0.0
+  end
+
+  # --- Data lookups (memoized) ---
+
+  def recipe_usage_counts
+    @recipe_usage_counts ||= MealPlanMeal
+      .joins(meal_plan_day: :meal_plan)
+      .where(meal_plan_days: { meal_plans: { account_id: @account.id } })
+      .where.not(meal_plan_days: { meal_plan_id: @meal_plan.id })
+      .group(:recipe_id)
+      .count
+  end
+
+  def recipe_last_used_dates
+    @recipe_last_used_dates ||= MealPlanMeal
+      .joins(meal_plan_day: :meal_plan)
+      .where(meal_plan_days: { meal_plans: { account_id: @account.id } })
+      .where.not(meal_plan_days: { meal_plan_id: @meal_plan.id })
+      .group(:recipe_id)
+      .maximum("meal_plan_days.date")
+  end
+
+  def participant_diet_slugs
+    @participant_diet_slugs ||= @participant_diets.filter_map do |diet_name|
+      DietCategorizer::DIET_TAG_SLUGS[diet_name]
+    end.uniq
+  end
+
+  def map_meal_types_to_categories
+    @map_meal_types_to_categories ||= @meal_types.map do |mt|
+      case mt
+      when "breakfast" then "breakfast"
+      when "lunch" then "lunch"
+      when "dinner" then "dinner"
+      when "snack" then "snacks"
+      end
+    end.compact.uniq
+  end
+end

--- a/config/initializers/ai.rb
+++ b/config/initializers/ai.rb
@@ -2,4 +2,5 @@
 
 module Ai
   mattr_accessor :default_model, default: "claude-sonnet-4-20250514"
+  mattr_accessor :meal_planning_model, default: "claude-haiku-4-5-20251001"
 end

--- a/test/controllers/accounts/api/v1/meal_planning/recipes_controller_test.rb
+++ b/test/controllers/accounts/api/v1/meal_planning/recipes_controller_test.rb
@@ -61,7 +61,7 @@ class Accounts::Api::V1::MealPlanning::RecipesControllerTest < ActionDispatch::I
     assert_response :not_found
   end
 
-  test "meal planning response includes ingredients summary" do
+  test "meal planning response includes essential fields only" do
     get "/#{@account.external_account_id}/api/v1/meal_planning/recipes",
         headers: auth_header(@read_token)
 
@@ -69,18 +69,12 @@ class Accounts::Api::V1::MealPlanning::RecipesControllerTest < ActionDispatch::I
     json = JSON.parse(response.body)
 
     recipe_data = json["recipes"].find { |r| r["id"] == @recipe.id }
-    assert_includes recipe_data["ingredients_summary"], "Salmon"
-  end
-
-  test "meal planning response includes recipe URL" do
-    get "/#{@account.external_account_id}/api/v1/meal_planning/recipes",
-        headers: auth_header(@read_token)
-
-    assert_response :success
-    json = JSON.parse(response.body)
-
-    recipe_data = json["recipes"].find { |r| r["id"] == @recipe.id }
-    assert_includes recipe_data["url"], @account.external_account_id.to_s
-    assert_includes recipe_data["url"], @recipe.id
+    assert_includes recipe_data.keys, "title"
+    assert_includes recipe_data.keys, "category"
+    assert_includes recipe_data.keys, "servings"
+    assert_includes recipe_data.keys, "tags"
+    # Trimmed fields should not be present (reduces AI token costs)
+    assert_nil recipe_data["url"]
+    assert_nil recipe_data["ingredients_summary"]
   end
 end

--- a/test/models/recipe_test.rb
+++ b/test/models/recipe_test.rb
@@ -91,7 +91,10 @@ class RecipeTest < ActiveSupport::TestCase
 
     assert_equal recipe.id, response[:id]
     assert_equal recipe.title, response[:title]
-    assert_includes response[:url], recipe.account.external_account_id.to_s
+    assert_equal recipe.category, response[:category]
+    assert response[:nutrition_per_serving].present?
+    assert_nil response[:url], "url should not be included in meal planning response"
+    assert_nil response[:ingredients_summary], "ingredients_summary should not be included"
   end
 
   test "has many tags through recipe_tags" do

--- a/test/services/meal_plan_generator_test.rb
+++ b/test/services/meal_plan_generator_test.rb
@@ -89,13 +89,14 @@ class MealPlanGeneratorTest < ActiveSupport::TestCase
   end
 
   test "skips unknown recipe ids from AI response" do
+    # AI now returns integer indices; 999 is an invalid index not in the mapping
     response = {
-      "days" => [
+      days: [
         {
-          "day_number" => 1,
-          "meals" => [
-            { "meal_type" => "breakfast", "recipe_id" => "nonexistent_id" },
-            { "meal_type" => "dinner", "recipe_id" => recipes(:one).id }
+          day_number: 1,
+          meals: [
+            { meal_type: "breakfast", recipe_id: 999 },
+            { meal_type: "dinner", recipe_id: 1 }
           ]
         }
       ]
@@ -109,13 +110,14 @@ class MealPlanGeneratorTest < ActiveSupport::TestCase
     assert_equal 1, day_one.meals.count
   end
 
-  test "clamps servings to valid range" do
+  test "assigns default servings of 1.0 for all meals" do
+    # Servings are no longer returned by AI — hardcoded to 1.0
     response = {
-      "days" => [
+      days: [
         {
-          "day_number" => 1,
-          "meals" => [
-            { "meal_type" => "dinner", "recipe_id" => recipes(:one).id, "servings" => 50.0 }
+          day_number: 1,
+          meals: [
+            { meal_type: "dinner", recipe_id: 1 }
           ]
         }
       ]
@@ -127,7 +129,7 @@ class MealPlanGeneratorTest < ActiveSupport::TestCase
     generator.generate
 
     meal = @meal_plan.days.find_by(day_number: 1).meals.first
-    assert_equal 10.0, meal.servings.to_f
+    assert_equal 1.0, meal.servings.to_f
   end
 
   test "reports progress via callback" do
@@ -171,9 +173,9 @@ class MealPlanGeneratorTest < ActiveSupport::TestCase
   end
 
   def build_ai_response(plan, meal_types: %w[breakfast lunch dinner snack])
-    salmon = recipes(:one)
-    eggs = recipes(:two)
-    recipe_ids = [ salmon.id, eggs.id ]
+    # AI now returns integer indices (1-based) instead of UUIDs.
+    # RecipeSelector returns eligible recipes; indices 1 and 2 map to the first two.
+    recipe_indices = [ 1, 2 ]
 
     # Use symbol keys to match real Anthropic gem behavior (tool_block.input.to_h returns symbols)
     {
@@ -181,11 +183,10 @@ class MealPlanGeneratorTest < ActiveSupport::TestCase
         {
           day_number: day.day_number,
           meals: meal_types.map do |mt|
-            { meal_type: mt, recipe_id: recipe_ids.sample, servings: 1.0 }
+            { meal_type: mt, recipe_id: recipe_indices.sample }
           end
         }
-      end,
-      reasoning: "Test plan with varied meals"
+      end
     }
   end
 end

--- a/test/services/recipe_selector_test.rb
+++ b/test/services/recipe_selector_test.rb
@@ -1,0 +1,266 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RecipeSelectorTest < ActiveSupport::TestCase
+  setup do
+    @account = accounts(:one)
+    @meal_types = %w[breakfast lunch dinner snack]
+    @current_date = Date.new(2026, 6, 1)
+  end
+
+  test "returns all recipes when catalog is smaller than limit" do
+    plan = create_target_plan
+    selector = build_selector(plan)
+
+    result = selector.select(limit: 100)
+
+    assert_equal eligible_recipe_count, result.size
+  end
+
+  test "returns only recipes with nutrition data" do
+    # Create a recipe without nutrition data
+    no_nutrition = @account.recipes.create!(title: "No Nutrition", category: :dinner, servings: 4)
+    plan = create_target_plan
+
+    selector = build_selector(plan)
+    result = selector.select(limit: 100)
+
+    refute_includes result.map(&:id), no_nutrition.id
+  ensure
+    no_nutrition&.destroy
+  end
+
+  test "hard excludes recipes from the most recent past plan" do
+    # Create enough recipes to trigger hard exclusion (>= 20)
+    extra_recipes = create_recipes_with_nutrition(18, category: :dinner)
+    past_plan = create_past_plan_using([ extra_recipes.first, extra_recipes.second ])
+    plan = create_target_plan
+
+    # Also clean up the fixture current plan's meals so they don't interfere with
+    # which plan is "most recent past"
+    fixture_plan = meal_plans(:one)
+    fixture_plan.update!(end_date: @current_date + 10.days) # Make it not "past" relative to @current_date
+
+    selector = build_selector(plan)
+
+    # Verify the past plan is discoverable
+    past_plans = @account.meal_plans.where.not(id: plan.id).where("end_date < ?", @current_date).order(start_date: :desc)
+    assert past_plans.any?, "Should find past plans"
+    most_recent = past_plans.first
+    assert_equal past_plan.id, most_recent.id, "Test past plan should be most recent"
+    assert most_recent.days.flat_map(&:meals).any?, "Past plan should have meals"
+
+    result = selector.select(limit: 100)
+    result_ids = result.map(&:id)
+
+    # Recipes used in the past plan should be excluded
+    refute_includes result_ids, extra_recipes.first.id
+    refute_includes result_ids, extra_recipes.second.id
+  ensure
+    fixture_plan&.update!(end_date: Date.current + 6.days) # restore
+    past_plan&.destroy
+    extra_recipes&.each(&:destroy)
+  end
+
+  test "skips hard exclusion for small catalogs under threshold" do
+    # With only 3 fixture recipes (< 20), hard exclusion is skipped
+    past_plan = create_past_plan_using([ recipes(:one) ])
+    plan = create_target_plan
+
+    selector = build_selector(plan)
+    result = selector.select(limit: 100)
+
+    # Should still include the recipe from the past plan since catalog is small
+    assert_includes result.map(&:id), recipes(:one).id
+  ensure
+    past_plan&.destroy
+  end
+
+  test "does not exclude recipes when no past plans exist" do
+    plan = create_target_plan
+
+    selector = build_selector(plan)
+    result = selector.select(limit: 100)
+
+    assert_equal eligible_recipe_count, result.size
+  end
+
+  test "scores recipes with diet compatibility when participant diets provided" do
+    # Set diet_scores on a recipe
+    recipes(:one).nutrition_data.update_column(:diet_scores, { "keto" => 0.95, "standard" => 0.3 })
+    recipes(:two).nutrition_data.update_column(:diet_scores, { "keto" => 0.2, "standard" => 0.9 })
+
+    plan = create_target_plan
+    selector = RecipeSelector.new(
+      @account, plan,
+      meal_types: @meal_types,
+      participant_diets: [ "Ketogenic (Keto)" ],
+      current_date: @current_date
+    )
+
+    result = selector.select(limit: 100)
+
+    # Both should be included (small catalog) but salmon should score higher on diet compatibility
+    assert_includes result.map(&:id), recipes(:one).id
+    assert_includes result.map(&:id), recipes(:two).id
+  ensure
+    recipes(:one).nutrition_data.update_column(:diet_scores, nil)
+    recipes(:two).nutrition_data.update_column(:diet_scores, nil)
+  end
+
+  test "handles nil diet_scores gracefully" do
+    recipes(:one).nutrition_data.update_column(:diet_scores, nil)
+    plan = create_target_plan
+
+    selector = RecipeSelector.new(
+      @account, plan,
+      meal_types: @meal_types,
+      participant_diets: [ "Ketogenic (Keto)" ],
+      current_date: @current_date
+    )
+
+    # Should not raise
+    result = selector.select(limit: 100)
+    assert result.any?
+  end
+
+  test "category fit boosts recipes matching active meal types" do
+    extra_recipes = create_recipes_with_nutrition(20, category: :dinner)
+    breakfast_recipes = create_recipes_with_nutrition(5, category: :breakfast)
+    plan = create_target_plan
+
+    selector = RecipeSelector.new(
+      @account, plan,
+      meal_types: %w[breakfast],
+      current_date: @current_date
+    )
+
+    result = selector.select(limit: 10)
+    breakfast_count = result.count { |r| r.category == "breakfast" }
+    non_breakfast_count = result.size - breakfast_count
+
+    # Breakfast recipes should be at least as many as non-breakfast recipes
+    # (hard exclusion may remove 1 breakfast fixture recipe used in a past plan)
+    assert breakfast_count >= non_breakfast_count,
+      "Expected at least as many breakfast (#{breakfast_count}) as non-breakfast (#{non_breakfast_count}) recipes"
+  ensure
+    extra_recipes&.each(&:destroy)
+    breakfast_recipes&.each(&:destroy)
+  end
+
+  test "newness bonus boosts recently created recipes" do
+    old_recipe = @account.recipes.create!(title: "Old Recipe", category: :dinner, servings: 4, created_at: 2.months.ago)
+    old_recipe.create_nutrition_data!(calories: 300, fat: 15, protein: 25, carbs: 5, net_carbs: 5)
+    new_recipe = @account.recipes.create!(title: "New Recipe", category: :dinner, servings: 4, created_at: @current_date - 3.days)
+    new_recipe.create_nutrition_data!(calories: 350, fat: 18, protein: 30, carbs: 4, net_carbs: 4)
+
+    plan = create_target_plan
+
+    selector = build_selector(plan)
+    result = selector.select(limit: 100)
+
+    assert_includes result.map(&:id), new_recipe.id
+    assert_includes result.map(&:id), old_recipe.id
+  ensure
+    old_recipe&.destroy
+    new_recipe&.destroy
+  end
+
+  test "respects minimum per category floor" do
+    # Create recipes across multiple categories
+    breakfast_recipes = create_recipes_with_nutrition(5, category: :breakfast)
+    dinner_recipes = create_recipes_with_nutrition(30, category: :dinner)
+    plan = create_target_plan
+
+    selector = RecipeSelector.new(
+      @account, plan,
+      meal_types: %w[breakfast dinner],
+      current_date: @current_date
+    )
+
+    result = selector.select(limit: 15)
+    breakfast_count = result.count { |r| r.category == "breakfast" }
+
+    # Should have at least MIN_PER_CATEGORY breakfast recipes
+    assert breakfast_count >= RecipeSelector::MIN_PER_CATEGORY
+  ensure
+    breakfast_recipes&.each(&:destroy)
+    dinner_recipes&.each(&:destroy)
+  end
+
+  test "select returns at most limit recipes" do
+    extra_recipes = create_recipes_with_nutrition(60, category: :dinner)
+    plan = create_target_plan
+
+    selector = build_selector(plan)
+    result = selector.select(limit: 25)
+
+    assert result.size <= 25
+  ensure
+    extra_recipes&.each(&:destroy)
+  end
+
+  private
+
+  def build_selector(plan)
+    RecipeSelector.new(
+      @account, plan,
+      meal_types: @meal_types,
+      current_date: @current_date
+    )
+  end
+
+  def eligible_recipe_count
+    @account.recipes.joins(:nutrition_data).where.not(recipe_nutrition_data: { calories: nil }).count
+  end
+
+  def create_target_plan
+    start_date = @current_date + 1.day
+    plan = @account.meal_plans.create!(
+      name: "Test Plan",
+      start_date: start_date,
+      end_date: start_date + 6.days,
+      user: users(:one)
+    )
+    7.times do |i|
+      plan.days.create!(date: start_date + i.days, day_number: i + 1)
+    end
+    plan
+  end
+
+  def create_past_plan_using(recipes_used)
+    # Use a date just before @current_date so this is the most recent past plan
+    past_start = @current_date - 8.days
+    plan = @account.meal_plans.create!(
+      name: "Past Plan",
+      start_date: past_start,
+      end_date: past_start + 6.days,
+      user: users(:one)
+    )
+    day = plan.days.create!(date: past_start, day_number: 1)
+    recipes_used.each do |recipe|
+      day.meals.create!(recipe: recipe, meal_type: :dinner, servings: 1.0)
+    end
+    plan
+  end
+
+  def create_recipes_with_nutrition(count, category: :dinner)
+    count.times.map do |i|
+      recipe = @account.recipes.create!(
+        title: "Test Recipe #{category} #{i + 1} #{SecureRandom.hex(4)}",
+        category: category,
+        servings: 4,
+        created_at: @current_date - 1.month
+      )
+      recipe.create_nutrition_data!(
+        calories: 200 + (i * 10),
+        fat: 10 + i,
+        protein: 20 + i,
+        carbs: 5 + i,
+        net_carbs: 3 + i
+      )
+      recipe
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements 8 optimizations to dramatically reduce AI meal plan generation costs:

1. **Switch to Haiku 4.5** — ~90% cost reduction vs Sonnet (`Ai.meal_planning_model`)
2. **Prompt caching** — `cache_control: { type: "ephemeral" }` on static system prompt
3. **Integer indices** — Recipes sent as `#1`, `#2` instead of 36-char UUIDs
4. **Trimmed serialization** — Removed `url`, `ingredients_summary`, and micronutrients from `to_meal_planning_response`
5. **RecipeSelector service** — Hybrid ranking pre-filters recipes before AI call:
   - Hard exclusion of recipes from recent past plans
   - Weighted scoring (usage frequency, recency decay, diet compatibility, category fit, newness)
   - Category-proportional selection with minimum per-category floor
6. **Removed `reasoning` field** from tool schema
7. **Lowered `max_tokens`** from 8192 to 4096
8. **Removed `servings`** from AI output (hardcoded to 1.0, adjusted by PortionCalculator)

## Changes

- New `RecipeSelector` service with 11 tests
- Rewritten `MealPlanGenerator` with all cost optimizations
- Trimmed `Recipe#to_meal_planning_response` and `RecipeNutritionData#to_meal_planning_response`
- Added `Ai.meal_planning_model` config (`claude-haiku-4-5-20251001`)
- Updated existing tests for new integer index format and removed fields
- Updated CLAUDE.md with RecipeSelector and meal plan generation architecture

## Testing

- 758 tests, 0 failures
- Rubocop: 0 offenses on changed files
- Brakeman: 0 warnings
- bundler-audit and importmap audit: clean

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)