### PR TITLE
Add dietary profile and shopping list API endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,15 @@ Controllers under `app/controllers/accounts/api/v1/` inherit from `ActionControl
 - `GET /:account_id/api/v1/recipes/import_status/:task_id` — returns progress, result (when completed), or error
 - `POST /:account_id/api/v1/recipes/import_confirm/:task_id` — saves recipe from completed task, accepts optional `recipe` overrides
 
+**Dietary Profiles API** — CRUD endpoints with `DietRegistry.diet_names` in index meta:
+- `GET/POST /:account_id/api/v1/dietary_profiles` — list active profiles / create
+- `GET/PATCH/DELETE /:account_id/api/v1/dietary_profiles/:id` — show / update / soft-delete
+
+**Shopping Lists API** — nested under meal plans:
+- `GET /:account_id/api/v1/meal_plans/:meal_plan_id/shopping_list` — get latest list with items
+- `POST /:account_id/api/v1/meal_plans/:meal_plan_id/shopping_list` — generate via `ShoppingListGenerator`
+- `PATCH /:account_id/api/v1/meal_plans/:meal_plan_id/shopping_list/items/:id/toggle` — toggle item checked
+
 ### AI Service Layer
 
 `Ai::Client` (`app/services/ai/client.rb`) wraps the Anthropic Claude API via the `anthropic` gem. Configured in `config/initializers/ai.rb` (default model: `claude-sonnet-4-20250514`, meal planning model: `claude-haiku-4-5-20251001`).

--- a/app/controllers/accounts/api/v1/dietary_profiles_controller.rb
+++ b/app/controllers/accounts/api/v1/dietary_profiles_controller.rb
@@ -1,0 +1,75 @@
+class Accounts::Api::V1::DietaryProfilesController < Accounts::Api::V1::ApplicationController
+  before_action :require_write_permission!, only: %i[create update destroy]
+  before_action :set_dietary_profile, only: %i[show update destroy]
+
+  # GET /api/v1/dietary_profiles
+  def index
+    profiles = current_account.dietary_profiles.active.order(:name)
+
+    render json: {
+      dietary_profiles: profiles.map { |p| profile_response(p) },
+      meta: {
+        diet_names: DietRegistry.diet_names
+      }
+    }
+  end
+
+  # GET /api/v1/dietary_profiles/:id
+  def show
+    render json: { dietary_profile: profile_response(@dietary_profile) }
+  end
+
+  # POST /api/v1/dietary_profiles
+  def create
+    @dietary_profile = current_account.dietary_profiles.build(dietary_profile_params)
+
+    if @dietary_profile.save
+      render json: { dietary_profile: profile_response(@dietary_profile) }, status: :created
+    else
+      render json: { errors: @dietary_profile.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT /api/v1/dietary_profiles/:id
+  def update
+    if @dietary_profile.update(dietary_profile_params)
+      render json: { dietary_profile: profile_response(@dietary_profile) }
+    else
+      render json: { errors: @dietary_profile.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /api/v1/dietary_profiles/:id
+  def destroy
+    @dietary_profile.update!(active: false)
+    head :no_content
+  end
+
+  private
+
+  def set_dietary_profile
+    @dietary_profile = current_account.dietary_profiles.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "Dietary profile not found" }, status: :not_found
+  end
+
+  def dietary_profile_params
+    permitted = params.require(:dietary_profile).permit(:name, :diet_name, :daily_calories_target, :user_id)
+    permitted[:user_id] = nil if permitted[:user_id].blank?
+    permitted
+  end
+
+  def profile_response(profile)
+    {
+      id: profile.id,
+      name: profile.name,
+      diet_name: profile.diet_name,
+      daily_calories_target: profile.daily_calories_target,
+      macro_targets: profile.macro_targets,
+      user_id: profile.user_id,
+      active: profile.active,
+      created_at: profile.created_at,
+      updated_at: profile.updated_at
+    }
+  end
+end

--- a/app/controllers/accounts/api/v1/shopping_list_items_controller.rb
+++ b/app/controllers/accounts/api/v1/shopping_list_items_controller.rb
@@ -1,0 +1,24 @@
+class Accounts::Api::V1::ShoppingListItemsController < Accounts::Api::V1::ApplicationController
+  before_action :require_write_permission!
+  before_action :set_item
+
+  # PATCH /api/v1/meal_plans/:meal_plan_id/shopping_list/items/:id/toggle
+  def toggle
+    @item.update!(checked: !@item.checked)
+
+    render json: {
+      id: @item.id,
+      checked: @item.checked
+    }
+  end
+
+  private
+
+  def set_item
+    @item = ShoppingListItem.joins(shopping_list: :meal_plan)
+      .where(meal_plans: { account_id: current_account.id, id: params[:meal_plan_id] })
+      .find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "Shopping list item not found" }, status: :not_found
+  end
+end

--- a/app/controllers/accounts/api/v1/shopping_lists_controller.rb
+++ b/app/controllers/accounts/api/v1/shopping_lists_controller.rb
@@ -1,0 +1,65 @@
+class Accounts::Api::V1::ShoppingListsController < Accounts::Api::V1::ApplicationController
+  before_action :require_write_permission!, only: :create
+  before_action :set_meal_plan
+  before_action :set_user, only: :create
+
+  # GET /api/v1/meal_plans/:meal_plan_id/shopping_list
+  def show
+    shopping_list = @meal_plan.shopping_lists.order(created_at: :desc).first
+
+    unless shopping_list
+      render json: { error: "No shopping list found for this meal plan" }, status: :not_found
+      return
+    end
+
+    render json: { shopping_list: shopping_list_response(shopping_list) }
+  end
+
+  # POST /api/v1/meal_plans/:meal_plan_id/shopping_list
+  def create
+    shopping_list = ShoppingListGenerator.new(@meal_plan, user: @user).generate
+
+    render json: { shopping_list: shopping_list_response(shopping_list) }, status: :created
+  end
+
+  private
+
+  def set_meal_plan
+    @meal_plan = current_account.meal_plans.find(params[:meal_plan_id])
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "Meal plan not found" }, status: :not_found
+  end
+
+  def set_user
+    @user = current_account.users.find_by(identity: current_identity)
+
+    unless @user
+      render json: { error: "User not found in this account" }, status: :forbidden
+    end
+  end
+
+  def shopping_list_response(list)
+    {
+      id: list.id,
+      name: list.name,
+      meal_plan_id: list.meal_plan_id,
+      checked_count: list.checked_count,
+      total_count: list.total_count,
+      all_checked: list.all_checked?,
+      items: list.items.alphabetical.map { |item| item_response(item) },
+      created_at: list.created_at,
+      updated_at: list.updated_at
+    }
+  end
+
+  def item_response(item)
+    {
+      id: item.id,
+      name: item.name,
+      quantity: item.quantity,
+      unit: item.unit,
+      checked: item.checked,
+      display_text: item.display_text
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,7 +109,17 @@ Rails.application.routes.draw do
           resources :recipes, only: %i[index show]
         end
 
-        resources :meal_plans, only: %i[index show create update destroy]
+        resources :meal_plans, only: %i[index show create update destroy] do
+          resource :shopping_list, only: %i[show create], controller: "shopping_lists" do
+            resources :items, only: [], controller: "shopping_list_items" do
+              member do
+                patch :toggle
+              end
+            end
+          end
+        end
+
+        resources :dietary_profiles, only: %i[index show create update destroy]
       end
     end
   end

--- a/test/controllers/accounts/api/v1/dietary_profiles_controller_test.rb
+++ b/test/controllers/accounts/api/v1/dietary_profiles_controller_test.rb
@@ -1,0 +1,167 @@
+require "test_helper"
+
+class Accounts::Api::V1::DietaryProfilesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @account = accounts(:one)
+    @read_token = identity_access_tokens(:read_token)
+    @write_token = identity_access_tokens(:write_token)
+    @profile = dietary_profiles(:dad)
+  end
+
+  def auth_header(token)
+    { "Authorization" => "Bearer #{token.token}" }
+  end
+
+  def api_url(path = "")
+    "/#{@account.external_account_id}/api/v1/dietary_profiles#{path}"
+  end
+
+  # ===========================================================================
+  # GET index
+  # ===========================================================================
+
+  test "index requires authentication" do
+    get api_url
+    assert_response :unauthorized
+  end
+
+  test "index returns active dietary profiles" do
+    get api_url, headers: auth_header(@read_token)
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert json["dietary_profiles"].is_a?(Array)
+    names = json["dietary_profiles"].map { |p| p["name"] }
+    assert_includes names, "Dad"
+    assert_includes names, "Mom"
+    assert_not_includes names, "Grandpa" # inactive
+  end
+
+  test "index includes diet_names in meta" do
+    get api_url, headers: auth_header(@read_token)
+
+    json = JSON.parse(response.body)
+    assert json["meta"]["diet_names"].is_a?(Array)
+    assert json["meta"]["diet_names"].length > 0
+  end
+
+  test "index includes macro_targets for profiles with diet" do
+    get api_url, headers: auth_header(@read_token)
+
+    json = JSON.parse(response.body)
+    dad = json["dietary_profiles"].find { |p| p["name"] == "Dad" }
+    assert dad["macro_targets"].present?
+    assert dad["macro_targets"]["calories"].present?
+  end
+
+  # ===========================================================================
+  # GET show
+  # ===========================================================================
+
+  test "show returns single profile" do
+    get api_url("/#{@profile.id}"), headers: auth_header(@read_token)
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal @profile.id, json["dietary_profile"]["id"]
+    assert_equal "Dad", json["dietary_profile"]["name"]
+  end
+
+  test "show returns 404 for nonexistent profile" do
+    get api_url("/nonexistent"), headers: auth_header(@read_token)
+    assert_response :not_found
+  end
+
+  # ===========================================================================
+  # POST create
+  # ===========================================================================
+
+  test "create requires write permission" do
+    post api_url,
+         params: { dietary_profile: { name: "Test" } },
+         headers: auth_header(@read_token),
+         as: :json
+    assert_response :forbidden
+  end
+
+  test "create creates a dietary profile" do
+    assert_difference "DietaryProfile.count" do
+      post api_url,
+           params: {
+             dietary_profile: {
+               name: "Toddler",
+               diet_name: "Ketogenic (Keto)",
+               daily_calories_target: 1200
+             }
+           },
+           headers: auth_header(@write_token),
+           as: :json
+    end
+
+    assert_response :created
+    json = JSON.parse(response.body)
+    assert_equal "Toddler", json["dietary_profile"]["name"]
+    assert_equal 1200, json["dietary_profile"]["daily_calories_target"]
+  end
+
+  test "create returns validation errors" do
+    post api_url,
+         params: { dietary_profile: { name: "" } },
+         headers: auth_header(@write_token),
+         as: :json
+
+    assert_response :unprocessable_entity
+    json = JSON.parse(response.body)
+    assert json["errors"].any? { |e| e.include?("Name") }
+  end
+
+  test "create rejects duplicate name" do
+    post api_url,
+         params: { dietary_profile: { name: "Dad" } },
+         headers: auth_header(@write_token),
+         as: :json
+
+    assert_response :unprocessable_entity
+  end
+
+  # ===========================================================================
+  # PATCH update
+  # ===========================================================================
+
+  test "update requires write permission" do
+    patch api_url("/#{@profile.id}"),
+          params: { dietary_profile: { name: "Updated" } },
+          headers: auth_header(@read_token),
+          as: :json
+    assert_response :forbidden
+  end
+
+  test "update modifies the profile" do
+    patch api_url("/#{@profile.id}"),
+          params: { dietary_profile: { daily_calories_target: 2200 } },
+          headers: auth_header(@write_token),
+          as: :json
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal 2200, json["dietary_profile"]["daily_calories_target"]
+  end
+
+  # ===========================================================================
+  # DELETE destroy
+  # ===========================================================================
+
+  test "destroy requires write permission" do
+    delete api_url("/#{@profile.id}"), headers: auth_header(@read_token)
+    assert_response :forbidden
+  end
+
+  test "destroy soft-deletes the profile" do
+    assert_no_difference "DietaryProfile.count" do
+      delete api_url("/#{@profile.id}"), headers: auth_header(@write_token)
+    end
+
+    assert_response :no_content
+    assert_not @profile.reload.active
+  end
+end

--- a/test/controllers/accounts/api/v1/shopping_lists_controller_test.rb
+++ b/test/controllers/accounts/api/v1/shopping_lists_controller_test.rb
@@ -1,0 +1,140 @@
+require "test_helper"
+
+class Accounts::Api::V1::ShoppingListsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @account = accounts(:one)
+    @read_token = identity_access_tokens(:read_token)
+    @write_token = identity_access_tokens(:write_token)
+    @meal_plan = meal_plans(:one)
+    @shopping_list = shopping_lists(:one)
+    @unchecked_item = shopping_list_items(:salmon)
+    @checked_item = shopping_list_items(:eggs)
+  end
+
+  def auth_header(token)
+    { "Authorization" => "Bearer #{token.token}" }
+  end
+
+  def shopping_list_url(meal_plan_id = @meal_plan.id)
+    "/#{@account.external_account_id}/api/v1/meal_plans/#{meal_plan_id}/shopping_list"
+  end
+
+  def toggle_url(meal_plan_id, item_id)
+    "/#{@account.external_account_id}/api/v1/meal_plans/#{meal_plan_id}/shopping_list/items/#{item_id}/toggle"
+  end
+
+  # ===========================================================================
+  # GET show
+  # ===========================================================================
+
+  test "show requires authentication" do
+    get shopping_list_url
+    assert_response :unauthorized
+  end
+
+  test "show returns shopping list with items" do
+    get shopping_list_url, headers: auth_header(@read_token)
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    list = json["shopping_list"]
+    assert_equal @shopping_list.id, list["id"]
+    assert list["items"].is_a?(Array)
+    assert list["items"].length > 0
+    assert list.key?("checked_count")
+    assert list.key?("total_count")
+    assert list.key?("all_checked")
+  end
+
+  test "show returns items with details" do
+    get shopping_list_url, headers: auth_header(@read_token)
+
+    json = JSON.parse(response.body)
+    item = json["shopping_list"]["items"].find { |i| i["name"] == "Salmon Fillet" }
+    assert item.present?
+    assert_equal "2", item["quantity"]
+    assert_equal "lbs", item["unit"]
+    assert_equal false, item["checked"]
+    assert item["display_text"].present?
+  end
+
+  test "show returns 404 when no shopping list exists" do
+    past_plan = meal_plans(:past)
+    get shopping_list_url(past_plan.id), headers: auth_header(@read_token)
+
+    assert_response :not_found
+  end
+
+  test "show returns 404 for nonexistent meal plan" do
+    get shopping_list_url("nonexistent"), headers: auth_header(@read_token)
+    assert_response :not_found
+  end
+
+  # ===========================================================================
+  # POST create
+  # ===========================================================================
+
+  test "create requires authentication" do
+    post shopping_list_url
+    assert_response :unauthorized
+  end
+
+  test "create requires write permission" do
+    post shopping_list_url, headers: auth_header(@read_token)
+    assert_response :forbidden
+  end
+
+  test "create generates a shopping list" do
+    assert_difference "ShoppingList.count" do
+      post shopping_list_url, headers: auth_header(@write_token)
+    end
+
+    assert_response :created
+    json = JSON.parse(response.body)
+    assert json["shopping_list"]["id"].present?
+    assert json["shopping_list"]["items"].is_a?(Array)
+  end
+
+  # ===========================================================================
+  # PATCH toggle
+  # ===========================================================================
+
+  test "toggle requires authentication" do
+    patch toggle_url(@meal_plan.id, @unchecked_item.id)
+    assert_response :unauthorized
+  end
+
+  test "toggle requires write permission" do
+    patch toggle_url(@meal_plan.id, @unchecked_item.id), headers: auth_header(@read_token)
+    assert_response :forbidden
+  end
+
+  test "toggle checks an unchecked item" do
+    assert_not @unchecked_item.checked
+
+    patch toggle_url(@meal_plan.id, @unchecked_item.id), headers: auth_header(@write_token)
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert json["checked"]
+    assert @unchecked_item.reload.checked
+  end
+
+  test "toggle unchecks a checked item" do
+    assert @checked_item.checked
+
+    patch toggle_url(@meal_plan.id, @checked_item.id), headers: auth_header(@write_token)
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_not json["checked"]
+    assert_not @checked_item.reload.checked
+  end
+
+  test "toggle returns 404 for item in different meal plan" do
+    past_plan = meal_plans(:past)
+    patch toggle_url(past_plan.id, @unchecked_item.id), headers: auth_header(@write_token)
+
+    assert_response :not_found
+  end
+end


### PR DESCRIPTION
## Summary

Exposes dietary profile management and shopping list functionality via the JSON API for mobile and third-party clients. Adds three new API controllers with full test coverage.

## Changes

- **Routes**: Added dietary profiles CRUD and shopping list routes (nested under meal plans) to API v1
- **DietaryProfilesController**: Full CRUD with `DietRegistry.diet_names` in index meta, macro targets in responses, soft-delete on destroy
- **ShoppingListsController**: Generate shopping list via `ShoppingListGenerator`, retrieve latest list with items
- **ShoppingListItemsController**: Toggle item checked/unchecked state
- **Tests**: 27 new integration tests covering auth, permissions, happy paths, and error cases
- **Docs**: Updated CLAUDE.md with new API endpoint documentation

## API Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/:account_id/api/v1/dietary_profiles` | List active profiles with diet_names meta |
| POST | `/:account_id/api/v1/dietary_profiles` | Create a profile |
| GET | `/:account_id/api/v1/dietary_profiles/:id` | Show a profile |
| PATCH | `/:account_id/api/v1/dietary_profiles/:id` | Update a profile |
| DELETE | `/:account_id/api/v1/dietary_profiles/:id` | Soft-delete a profile |
| GET | `/:account_id/api/v1/meal_plans/:id/shopping_list` | Get latest shopping list |
| POST | `/:account_id/api/v1/meal_plans/:id/shopping_list` | Generate shopping list |
| PATCH | `/:account_id/api/v1/meal_plans/:id/shopping_list/items/:id/toggle` | Toggle item completion |

## Testing

- 27 new tests, all passing
- Full suite: 841 tests, 1 pre-existing failure (Ai::ClientTest, unrelated)
- Rubocop: 0 offenses on changed files
- Brakeman: no warnings
- bundler-audit: no vulnerabilities

Closes #19