### PR TITLE
Add meal plan generation API endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,12 @@ Controllers under `app/controllers/accounts/api/v1/` inherit from `ActionControl
 - `POST /:account_id/api/v1/meal_plans/:meal_plan_id/shopping_list` — generate via `ShoppingListGenerator`
 - `PATCH /:account_id/api/v1/meal_plans/:meal_plan_id/shopping_list/items/:id/toggle` — toggle item checked
 
+**Meal Plan Generation API** — async AI generation and modification:
+- `POST /:account_id/api/v1/meal_plans/generate` — creates plan, generates days, enqueues `MealPlanGenerationJob`, returns `{ task_id, meal_plan_id, status }`
+- `GET /:account_id/api/v1/meal_plans/generate_status/:task_id` — poll async generation progress
+- `POST /:account_id/api/v1/meal_plans/:id/swap_meal` — swap a meal's recipe (accepts `meal_id`, `recipe_id`)
+- `POST /:account_id/api/v1/meal_plans/:id/regenerate_day` — clear and re-generate meals for one day via AI (synchronous)
+
 ### AI Service Layer
 
 `Ai::Client` (`app/services/ai/client.rb`) wraps the Anthropic Claude API via the `anthropic` gem. Configured in `config/initializers/ai.rb` (default model: `claude-sonnet-4-20250514`, meal planning model: `claude-haiku-4-5-20251001`).

--- a/app/controllers/accounts/api/v1/meal_plans_controller.rb
+++ b/app/controllers/accounts/api/v1/meal_plans_controller.rb
@@ -1,7 +1,8 @@
 class Accounts::Api::V1::MealPlansController < Accounts::Api::V1::ApplicationController
-  before_action :require_write_permission!, only: %i[create update destroy]
-  before_action :set_meal_plan, only: %i[show update destroy]
-  before_action :set_user_for_create, only: :create
+  before_action :require_write_permission!, only: %i[create update destroy generate swap_meal regenerate_day]
+  before_action :set_meal_plan, only: %i[show update destroy swap_meal regenerate_day]
+  before_action :set_user_for_create, only: %i[create generate]
+  before_action :set_task, only: :generate_status
 
   # GET /api/v1/meal_plans
   def index
@@ -57,6 +58,103 @@ class Accounts::Api::V1::MealPlansController < Accounts::Api::V1::ApplicationCon
     head :no_content
   end
 
+  # POST /api/v1/meal_plans/generate
+  def generate
+    plan = current_account.meal_plans.build(meal_plan_params)
+    plan.user = @user
+
+    unless plan.save
+      render json: { errors: plan.errors.full_messages }, status: :unprocessable_entity
+      return
+    end
+
+    generate_days(plan)
+    attach_participants(plan, params[:dietary_profile_ids])
+
+    task = current_account.ai_task_statuses.create!(task_type: "meal_plan_generation")
+
+    MealPlanGenerationJob.perform_later(
+      task.id,
+      meal_plan_id: plan.id,
+      preferences: Array(params[:preferences]).reject(&:blank?),
+      special_requests: params[:special_requests].presence
+    )
+
+    render json: {
+      task_id: task.id,
+      meal_plan_id: plan.id,
+      status: task.status
+    }, status: :created
+  end
+
+  # GET /api/v1/meal_plans/generate_status/:task_id
+  def generate_status
+    response = {
+      task_id: @task.id,
+      status: @task.status,
+      progress_percentage: @task.progress_percentage
+    }
+
+    if @task.completed?
+      raw = @task.result
+      response[:result] = raw.is_a?(String) ? JSON.parse(raw) : raw
+    end
+    response[:error_message] = @task.error_message if @task.failed?
+
+    render json: response
+  end
+
+  # POST /api/v1/meal_plans/:id/swap_meal
+  def swap_meal
+    meal_id = params[:meal_id]
+    recipe_id = params[:recipe_id]
+
+    if meal_id.blank? || recipe_id.blank?
+      render json: { error: "meal_id and recipe_id are required" }, status: :bad_request
+      return
+    end
+
+    meal = @meal_plan.days.joins(:meals).where(meal_plan_meals: { id: meal_id }).first&.meals&.find_by(id: meal_id)
+    unless meal
+      render json: { error: "Meal not found in this plan" }, status: :not_found
+      return
+    end
+
+    recipe = current_account.recipes.find_by(id: recipe_id)
+    unless recipe
+      render json: { error: "Recipe not found" }, status: :not_found
+      return
+    end
+
+    meal.update!(recipe: recipe)
+
+    render json: { meal_plan: @meal_plan.reload.to_api_response }
+  end
+
+  # POST /api/v1/meal_plans/:id/regenerate_day
+  def regenerate_day
+    day_number = params[:day_number].to_i
+
+    day = @meal_plan.days.find_by(day_number: day_number)
+    unless day
+      render json: { error: "Day #{day_number} not found in this plan" }, status: :not_found
+      return
+    end
+
+    day.meals.destroy_all
+
+    generator = MealPlanGenerator.new(
+      @meal_plan.reload,
+      preferences: Array(params[:preferences]).reject(&:blank?),
+      special_requests: params[:special_requests].presence
+    )
+    generator.generate
+
+    render json: { meal_plan: @meal_plan.reload.to_api_response }
+  rescue MealPlanGenerator::GenerationError => e
+    render json: { error: e.message }, status: :unprocessable_entity
+  end
+
   private
 
   def set_meal_plan
@@ -68,11 +166,33 @@ class Accounts::Api::V1::MealPlansController < Accounts::Api::V1::ApplicationCon
   end
 
   def set_user_for_create
-    # Find the user associated with this identity in this account
     @user = current_account.users.find_by(identity: current_identity)
 
     unless @user
       render json: { error: "User not found in this account" }, status: :forbidden
+    end
+  end
+
+  def set_task
+    @task = current_account.ai_task_statuses.find(params[:task_id])
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "Task not found" }, status: :not_found
+  end
+
+  def generate_days(plan)
+    (plan.start_date..plan.end_date).each_with_index do |date, index|
+      plan.days.create!(date: date, day_number: index + 1)
+    end
+  end
+
+  def attach_participants(plan, profile_ids)
+    return unless profile_ids.present?
+
+    Array(profile_ids).reject(&:blank?).each do |profile_id|
+      profile = current_account.dietary_profiles.active.find_by(id: profile_id)
+      next unless profile
+
+      plan.participants.create!(dietary_profile: profile)
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,14 @@ Rails.application.routes.draw do
         end
 
         resources :meal_plans, only: %i[index show create update destroy] do
+          collection do
+            post :generate
+            get "generate_status/:task_id", action: :generate_status, as: :generate_status
+          end
+          member do
+            post :swap_meal
+            post :regenerate_day
+          end
           resource :shopping_list, only: %i[show create], controller: "shopping_lists" do
             resources :items, only: [], controller: "shopping_list_items" do
               member do

--- a/test/controllers/accounts/api/v1/meal_plans_controller_test.rb
+++ b/test/controllers/accounts/api/v1/meal_plans_controller_test.rb
@@ -158,6 +158,230 @@ class Accounts::Api::V1::MealPlansControllerTest < ActionDispatch::IntegrationTe
     assert json["errors"].any?
   end
 
+  # ===========================================================================
+  # POST generate
+  # ===========================================================================
+
+  test "generate requires authentication" do
+    post "/#{@account.external_account_id}/api/v1/meal_plans/generate"
+    assert_response :unauthorized
+  end
+
+  test "generate requires write permission" do
+    post "/#{@account.external_account_id}/api/v1/meal_plans/generate",
+         params: { meal_plan: { name: "AI Plan", start_date: Date.today, end_date: Date.today + 6.days } },
+         headers: auth_header(@read_token),
+         as: :json
+    assert_response :forbidden
+  end
+
+  test "generate creates plan and enqueues job" do
+    assert_difference [ "MealPlan.count", "AiTaskStatus.count" ] do
+      assert_enqueued_with(job: MealPlanGenerationJob) do
+        post "/#{@account.external_account_id}/api/v1/meal_plans/generate",
+             params: {
+               meal_plan: {
+                 name: "AI Generated Plan",
+                 start_date: Date.today,
+                 end_date: Date.today + 6.days,
+                 daily_calories_target: 2000
+               },
+               preferences: [ "no_repeats", "high_variety" ],
+               special_requests: "Extra protein"
+             },
+             headers: auth_header(@write_token),
+             as: :json
+      end
+    end
+
+    assert_response :created
+    json = JSON.parse(response.body)
+    assert json["task_id"].present?
+    assert json["meal_plan_id"].present?
+    assert_equal "pending", json["status"]
+
+    # Verify days were generated
+    plan = MealPlan.find(json["meal_plan_id"])
+    assert_equal 7, plan.days.count
+  end
+
+  test "generate returns validation errors for invalid plan" do
+    assert_no_difference "MealPlan.count" do
+      post "/#{@account.external_account_id}/api/v1/meal_plans/generate",
+           params: { meal_plan: { name: "Missing Dates" } },
+           headers: auth_header(@write_token),
+           as: :json
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  # ===========================================================================
+  # GET generate_status
+  # ===========================================================================
+
+  test "generate_status requires authentication" do
+    task = @account.ai_task_statuses.create!(task_type: "meal_plan_generation")
+    get "/#{@account.external_account_id}/api/v1/meal_plans/generate_status/#{task.id}"
+    assert_response :unauthorized
+  end
+
+  test "generate_status returns pending task" do
+    task = @account.ai_task_statuses.create!(task_type: "meal_plan_generation")
+
+    get "/#{@account.external_account_id}/api/v1/meal_plans/generate_status/#{task.id}",
+        headers: auth_header(@read_token)
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal "pending", json["status"]
+    assert_equal 0, json["progress_percentage"]
+  end
+
+  test "generate_status returns 404 for nonexistent task" do
+    get "/#{@account.external_account_id}/api/v1/meal_plans/generate_status/nonexistent",
+        headers: auth_header(@read_token)
+    assert_response :not_found
+  end
+
+  # ===========================================================================
+  # POST swap_meal
+  # ===========================================================================
+
+  test "swap_meal requires authentication" do
+    meal_plan = create_meal_plan_with_meals
+    post "/#{@account.external_account_id}/api/v1/meal_plans/#{meal_plan.id}/swap_meal"
+    assert_response :unauthorized
+  end
+
+  test "swap_meal requires write permission" do
+    meal_plan = create_meal_plan_with_meals
+    post "/#{@account.external_account_id}/api/v1/meal_plans/#{meal_plan.id}/swap_meal",
+         params: { meal_id: "x", recipe_id: "y" },
+         headers: auth_header(@read_token),
+         as: :json
+    assert_response :forbidden
+  end
+
+  test "swap_meal returns 400 when params missing" do
+    meal_plan = create_meal_plan_with_meals
+    post "/#{@account.external_account_id}/api/v1/meal_plans/#{meal_plan.id}/swap_meal",
+         headers: auth_header(@write_token),
+         as: :json
+    assert_response :bad_request
+  end
+
+  test "swap_meal swaps the recipe on a meal" do
+    meal_plan = create_meal_plan_with_meals
+    meal = meal_plan.days.first.meals.first
+    new_recipe = recipes(:two)
+
+    post "/#{@account.external_account_id}/api/v1/meal_plans/#{meal_plan.id}/swap_meal",
+         params: { meal_id: meal.id, recipe_id: new_recipe.id },
+         headers: auth_header(@write_token),
+         as: :json
+
+    assert_response :success
+    assert_equal new_recipe.id, meal.reload.recipe_id
+  end
+
+  test "swap_meal returns 404 for meal not in plan" do
+    meal_plan = create_meal_plan_with_meals
+    other_plan = create_meal_plan_with_meals
+    other_meal = other_plan.days.first.meals.first
+
+    post "/#{@account.external_account_id}/api/v1/meal_plans/#{meal_plan.id}/swap_meal",
+         params: { meal_id: other_meal.id, recipe_id: @recipe.id },
+         headers: auth_header(@write_token),
+         as: :json
+
+    assert_response :not_found
+  end
+
+  test "swap_meal returns 404 for nonexistent recipe" do
+    meal_plan = create_meal_plan_with_meals
+    meal = meal_plan.days.first.meals.first
+
+    post "/#{@account.external_account_id}/api/v1/meal_plans/#{meal_plan.id}/swap_meal",
+         params: { meal_id: meal.id, recipe_id: "nonexistent" },
+         headers: auth_header(@write_token),
+         as: :json
+
+    assert_response :not_found
+  end
+
+  # ===========================================================================
+  # POST regenerate_day
+  # ===========================================================================
+
+  test "regenerate_day requires authentication" do
+    meal_plan = create_meal_plan_with_meals
+    post "/#{@account.external_account_id}/api/v1/meal_plans/#{meal_plan.id}/regenerate_day"
+    assert_response :unauthorized
+  end
+
+  test "regenerate_day requires write permission" do
+    meal_plan = create_meal_plan_with_meals
+    post "/#{@account.external_account_id}/api/v1/meal_plans/#{meal_plan.id}/regenerate_day",
+         params: { day_number: 1 },
+         headers: auth_header(@read_token),
+         as: :json
+    assert_response :forbidden
+  end
+
+  test "regenerate_day returns 404 for invalid day number" do
+    meal_plan = create_meal_plan_with_meals
+    post "/#{@account.external_account_id}/api/v1/meal_plans/#{meal_plan.id}/regenerate_day",
+         params: { day_number: 99 },
+         headers: auth_header(@write_token),
+         as: :json
+    assert_response :not_found
+  end
+
+  test "regenerate_day clears meals and calls generator" do
+    meal_plan = create_meal_plan_with_meals
+    day = meal_plan.days.first
+    original_meal_count = day.meals.count
+    assert original_meal_count > 0
+
+    # Temporarily override MealPlanGenerator.new to return a fake
+    original_new = MealPlanGenerator.method(:new)
+    fake = Object.new
+    fake.define_singleton_method(:generate) { |&_block| { meals_assigned: 0, days_planned: 1 } }
+
+    MealPlanGenerator.define_singleton_method(:new) { |*_args, **_kwargs| fake }
+
+    post "/#{@account.external_account_id}/api/v1/meal_plans/#{meal_plan.id}/regenerate_day",
+         params: { day_number: 1 },
+         headers: auth_header(@write_token),
+         as: :json
+
+    assert_response :success
+  ensure
+    MealPlanGenerator.define_singleton_method(:new, original_new)
+  end
+
+  test "regenerate_day returns error when generator fails" do
+    meal_plan = create_meal_plan_with_meals
+
+    original_new = MealPlanGenerator.method(:new)
+    fake = Object.new
+    fake.define_singleton_method(:generate) { |&_block| raise MealPlanGenerator::GenerationError, "Not enough recipes" }
+
+    MealPlanGenerator.define_singleton_method(:new) { |*_args, **_kwargs| fake }
+
+    post "/#{@account.external_account_id}/api/v1/meal_plans/#{meal_plan.id}/regenerate_day",
+         params: { day_number: 1 },
+         headers: auth_header(@write_token),
+         as: :json
+
+    assert_response :unprocessable_entity
+    json = JSON.parse(response.body)
+    assert_equal "Not enough recipes", json["error"]
+  ensure
+    MealPlanGenerator.define_singleton_method(:new, original_new)
+  end
+
   test "should calculate daily totals correctly" do
     meal_plan = create_meal_plan_with_meals
 


### PR DESCRIPTION
## Summary

Exposes AI meal plan generation and modification via the JSON API. Adds async generation (create plan + enqueue AI job + poll status), meal swapping, and single-day regeneration.

## Changes

- **Routes**: Added `generate`, `generate_status/:task_id`, `swap_meal`, `regenerate_day` under `api/v1/meal_plans`
- **Controller**: Extended `MealPlansController` with 4 new actions plus helper methods (`generate_days`, `attach_participants`, `set_task`)
- **Tests**: 18 new integration tests covering auth, permissions, happy paths, error cases, and AI mock/stub patterns
- **Docs**: Updated CLAUDE.md with new API endpoint documentation

## API Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/:account_id/api/v1/meal_plans/generate` | Start async AI generation, returns `{ task_id, meal_plan_id, status }` |
| GET | `/:account_id/api/v1/meal_plans/generate_status/:task_id` | Poll generation progress |
| POST | `/:account_id/api/v1/meal_plans/:id/swap_meal` | Swap a meal's recipe (`meal_id` + `recipe_id`) |
| POST | `/:account_id/api/v1/meal_plans/:id/regenerate_day` | Clear and regenerate one day via AI |

## Testing

- 18 new tests, all passing
- Full suite: 859 tests, 1 pre-existing failure (Ai::ClientTest, unrelated)
- Rubocop: 0 offenses
- Brakeman: no warnings
- bundler-audit: no vulnerabilities

Closes #20