### PR TITLE
Add recipe image support with drag-and-drop upload

### DIFF
--- a/app/controllers/accounts/recipes_controller.rb
+++ b/app/controllers/accounts/recipes_controller.rb
@@ -72,6 +72,7 @@ class Accounts::RecipesController < ApplicationController
   end
 
   def update
+    purge_image_if_requested
     if @recipe.update(recipe_params)
       @recipe.sync_tags_from_list(params[:recipe][:tag_list], Current.account)
       handle_nutrition_after_save
@@ -209,6 +210,7 @@ class Accounts::RecipesController < ApplicationController
     build_ingredients_from_import(result[:ingredients] || [])
     build_instructions_from_import(result[:instructions] || [])
     build_nutrition_from_import(result[:nutrition])
+    attach_imported_image(result[:image_url])
 
     @recipe.ingredients.build if @recipe.ingredients.empty?
     @recipe.instructions.build if @recipe.instructions.empty?
@@ -320,6 +322,29 @@ class Accounts::RecipesController < ApplicationController
     )
   end
 
+  def attach_imported_image(image_url)
+    return if image_url.blank?
+
+    uri = URI.parse(image_url)
+    return unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+
+    response = Net::HTTP.get_response(uri)
+    return unless response.is_a?(Net::HTTPSuccess)
+
+    content_type = response["content-type"]&.split(";")&.first
+    return unless content_type&.in?(Recipe::ALLOWED_IMAGE_TYPES)
+
+    extension = content_type.split("/").last
+    @recipe.image.attach(
+      io: StringIO.new(response.body),
+      filename: "imported-cover.#{extension}",
+      content_type: content_type
+    )
+  rescue URI::InvalidURIError, SocketError, Timeout::Error, Errno::ECONNREFUSED
+    # Silently skip — image is optional
+    nil
+  end
+
   def parse_ingredient_text(text)
     # Match patterns like "2 cups almond flour" or "1/2 tsp salt"
     match = text.match(/\A([\d\s\/½¼¾⅓⅔⅛.]+)?\s*(#{Ingredient::UNITS_PATTERN})?\s*(.+)\z/i)
@@ -327,6 +352,13 @@ class Accounts::RecipesController < ApplicationController
       { quantity: match[1]&.strip, unit: match[2]&.strip&.downcase, name: match[3]&.strip }
     else
       { quantity: nil, unit: nil, name: text.strip }
+    end
+  end
+
+  def purge_image_if_requested
+    if params[:purge_image_id].present?
+      attachment = @recipe.images.find { |img| img.id.to_s == params[:purge_image_id].to_s }
+      attachment&.purge_later
     end
   end
 
@@ -340,6 +372,7 @@ class Accounts::RecipesController < ApplicationController
       :prep_time,
       :cook_time,
       :image,
+      images: [],
       ingredients_attributes: %i[id name quantity unit display_order _destroy],
       instructions_attributes: %i[id step_number instruction _destroy],
       nutrition_data_attributes: %i[

--- a/app/helpers/recipes_helper.rb
+++ b/app/helpers/recipes_helper.rb
@@ -13,7 +13,7 @@ module RecipesHelper
 
     if recipe.image.attached?
       content_tag(:div, class: "relative #{height} overflow-hidden") do
-        image_tag(recipe.image.variant(resize_to_fill: [ 600, 300 ]),
+        image_tag(recipe.image.variant(:card),
           class: "w-full h-full object-cover",
           loading: "lazy",
           alt: recipe.title) +
@@ -32,7 +32,7 @@ module RecipesHelper
 
     if recipe.image.attached?
       content_tag(:div, class: "relative h-64 sm:h-80 overflow-hidden rounded-t-lg") do
-        image_tag(recipe.image.variant(resize_to_fill: [ 1200, 500 ]),
+        image_tag(recipe.image.variant(:full),
           class: "w-full h-full object-cover",
           alt: recipe.title) +
         content_tag(:div, "", class: "absolute inset-0 bg-gradient-to-t from-black/30 to-transparent")

--- a/app/javascript/controllers/image_upload_controller.js
+++ b/app/javascript/controllers/image_upload_controller.js
@@ -1,0 +1,173 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Drag-and-drop image upload with live preview
+// Supports single (cover) and multiple (additional) image uploads
+export default class extends Controller {
+  static targets = ["input", "dropZone", "preview", "placeholder"]
+  static values = {
+    multiple: { type: Boolean, default: false },
+    maxSize: { type: Number, default: 10485760 }, // 10MB
+    accept: { type: String, default: "image/jpeg,image/png,image/webp,image/gif" }
+  }
+
+  connect() {
+    this.dragCounter = 0
+  }
+
+  // Drag events
+  dragenter(event) {
+    event.preventDefault()
+    this.dragCounter++
+    this.dropZoneTarget.classList.add("border-primary-400", "bg-primary-50/50")
+    this.dropZoneTarget.classList.remove("border-warm-300")
+  }
+
+  dragleave(event) {
+    event.preventDefault()
+    this.dragCounter--
+    if (this.dragCounter === 0) {
+      this.dropZoneTarget.classList.remove("border-primary-400", "bg-primary-50/50")
+      this.dropZoneTarget.classList.add("border-warm-300")
+    }
+  }
+
+  dragover(event) {
+    event.preventDefault()
+  }
+
+  drop(event) {
+    event.preventDefault()
+    this.dragCounter = 0
+    this.dropZoneTarget.classList.remove("border-primary-400", "bg-primary-50/50")
+    this.dropZoneTarget.classList.add("border-warm-300")
+
+    const files = event.dataTransfer.files
+    if (files.length > 0) {
+      this.handleFiles(files)
+    }
+  }
+
+  // Click to browse
+  browse() {
+    this.inputTarget.click()
+  }
+
+  // File input changed
+  changed() {
+    const files = this.inputTarget.files
+    if (files.length > 0) {
+      this.handleFiles(files)
+    }
+  }
+
+  handleFiles(files) {
+    const validFiles = Array.from(files).filter(file => this.validateFile(file))
+
+    if (!this.multipleValue) {
+      // Single file mode — show one preview, replace existing
+      if (validFiles.length > 0) {
+        this.showSinglePreview(validFiles[0])
+      }
+    } else {
+      // Multiple file mode — append previews
+      validFiles.forEach(file => this.appendPreview(file))
+    }
+  }
+
+  validateFile(file) {
+    const allowedTypes = this.acceptValue.split(",").map(t => t.trim())
+
+    if (!allowedTypes.includes(file.type)) {
+      this.showError(`"${file.name}" is not a supported image type. Use JPEG, PNG, WebP, or GIF.`)
+      return false
+    }
+
+    if (file.size > this.maxSizeValue) {
+      const maxMB = Math.round(this.maxSizeValue / 1048576)
+      this.showError(`"${file.name}" exceeds the ${maxMB}MB size limit.`)
+      return false
+    }
+
+    return true
+  }
+
+  showSinglePreview(file) {
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      this.previewTarget.innerHTML = `
+        <div class="relative inline-block group">
+          <img src="${e.target.result}" class="rounded-xl shadow-sm max-h-48 object-cover" alt="Preview">
+          <button type="button" data-action="image-upload#clearSingle"
+            class="absolute -top-2 -right-2 w-6 h-6 bg-red-500 text-white rounded-full flex items-center justify-center
+                   opacity-0 group-hover:opacity-100 transition-opacity shadow-sm hover:bg-red-600">
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+            </svg>
+          </button>
+          <p class="text-xs text-warm-500 mt-1.5">${file.name} (${this.formatSize(file.size)})</p>
+        </div>
+      `
+      this.previewTarget.classList.remove("hidden")
+      if (this.hasPlaceholderTarget) {
+        this.placeholderTarget.classList.add("hidden")
+      }
+    }
+    reader.readAsDataURL(file)
+  }
+
+  appendPreview(file) {
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      const wrapper = document.createElement("div")
+      wrapper.className = "relative inline-block group"
+      wrapper.innerHTML = `
+        <img src="${e.target.result}" class="w-20 h-20 rounded-lg object-cover shadow-sm" alt="Preview">
+        <button type="button" data-action="image-upload#removePreview"
+          class="absolute -top-1.5 -right-1.5 w-5 h-5 bg-red-500 text-white rounded-full flex items-center justify-center
+                 opacity-0 group-hover:opacity-100 transition-opacity shadow-sm hover:bg-red-600">
+          <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+          </svg>
+        </button>
+        <p class="text-[10px] text-warm-500 mt-0.5 truncate max-w-[5rem]">${file.name}</p>
+      `
+      this.previewTarget.appendChild(wrapper)
+      this.previewTarget.classList.remove("hidden")
+    }
+    reader.readAsDataURL(file)
+  }
+
+  clearSingle() {
+    this.inputTarget.value = ""
+    this.previewTarget.innerHTML = ""
+    this.previewTarget.classList.add("hidden")
+    if (this.hasPlaceholderTarget) {
+      this.placeholderTarget.classList.remove("hidden")
+    }
+  }
+
+  removePreview(event) {
+    const wrapper = event.currentTarget.closest(".group")
+    if (wrapper) {
+      wrapper.remove()
+    }
+    // Note: removing the preview doesn't remove the file from the input.
+    // For multi-file, the form will submit all selected files.
+    // Removal of individual files from a FileList isn't supported natively.
+  }
+
+  showError(message) {
+    // Brief inline error that auto-dismisses
+    const el = document.createElement("div")
+    el.className = "text-sm text-red-600 mt-1 animate-pulse"
+    el.textContent = message
+    this.dropZoneTarget.after(el)
+    setTimeout(() => el.remove(), 4000)
+  }
+
+  formatSize(bytes) {
+    if (bytes < 1024) return `${bytes} B`
+    if (bytes < 1048576) return `${(bytes / 1024).toFixed(1)} KB`
+    return `${(bytes / 1048576).toFixed(1)} MB`
+  }
+}

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,8 +1,16 @@
 class Recipe < ApplicationRecord
   include Identifiable
 
+  ALLOWED_IMAGE_TYPES = %w[image/jpeg image/png image/webp image/gif].freeze
+  MAX_IMAGE_SIZE = 10.megabytes
+
   belongs_to :account
-  has_one_attached :image
+  has_one_attached :image do |attachable|
+    attachable.variant :thumbnail, resize_to_fill: [ 200, 200 ]
+    attachable.variant :card, resize_to_fill: [ 400, 300 ]
+    attachable.variant :full, resize_to_fill: [ 1200, 800 ]
+  end
+  has_many_attached :images
   has_many :ingredients, -> { order(:display_order) }, dependent: :destroy
   has_many :instructions, class_name: "RecipeInstruction", dependent: :destroy
   has_one :nutrition_data, class_name: "RecipeNutritionData", dependent: :destroy
@@ -13,6 +21,8 @@ class Recipe < ApplicationRecord
 
   validates :title, presence: true
   validates :category, presence: true
+  validate :validate_image_attachment
+  validate :validate_images_attachments
 
   enum :category, {
     breakfast: 0,
@@ -129,5 +139,29 @@ class Recipe < ApplicationRecord
       nutrition_per_serving: nutrition_data&.to_meal_planning_response,
       tags: tags.pluck(:name)
     }
+  end
+
+  private
+
+  def validate_image_attachment
+    validate_single_image(image, :image) if image.attached?
+  end
+
+  def validate_images_attachments
+    return unless images.attached?
+
+    images.each do |img|
+      validate_single_image(img, :images)
+    end
+  end
+
+  def validate_single_image(img, attribute)
+    unless img.blob.content_type.in?(ALLOWED_IMAGE_TYPES)
+      errors.add(attribute, "must be a JPEG, PNG, WebP, or GIF file")
+    end
+
+    if img.blob.byte_size > MAX_IMAGE_SIZE
+      errors.add(attribute, "must be less than 10MB")
+    end
   end
 end

--- a/app/services/recipe_import/json_ld_parser.rb
+++ b/app/services/recipe_import/json_ld_parser.rb
@@ -74,6 +74,7 @@ module RecipeImport
         ingredients: parse_ingredients(data["recipeIngredient"]),
         instructions: parse_instructions(data["recipeInstructions"]),
         nutrition: parse_nutrition(data["nutrition"]),
+        image_url: extract_image_url(data["image"]),
         source: data["url"] || data["mainEntityOfPage"]
       }.compact
     end
@@ -137,6 +138,14 @@ module RecipeImport
     def extract_number(value)
       return nil unless value
       value.to_s[/[\d.]+/]&.to_f&.round(1)
+    end
+
+    def extract_image_url(value)
+      case value
+      when String then value.strip.presence
+      when Hash then value["url"]&.to_s&.strip&.presence
+      when Array then extract_image_url(value.first)
+      end
     end
   end
 end

--- a/app/views/accounts/meal_plans/_calendar_cell.html.erb
+++ b/app/views/accounts/meal_plans/_calendar_cell.html.erb
@@ -7,7 +7,7 @@
         <div class="flex items-start gap-1.5">
           <% if meal.recipe.image.attached? %>
             <div class="w-8 h-8 rounded overflow-hidden shrink-0">
-              <%= image_tag meal.recipe.image.variant(resize_to_fill: [64, 64]), class: "w-full h-full object-cover", loading: "lazy", alt: meal.recipe.title %>
+              <%= image_tag meal.recipe.image.variant(:thumbnail), class: "w-full h-full object-cover", loading: "lazy", alt: meal.recipe.title %>
             </div>
           <% end %>
           <div class="flex-1 min-w-0">

--- a/app/views/accounts/meal_plans/show.html.erb
+++ b/app/views/accounts/meal_plans/show.html.erb
@@ -164,7 +164,7 @@
                       <div class="flex items-center gap-3 py-1.5">
                         <% if meal.recipe.image.attached? %>
                           <div class="w-10 h-10 rounded-lg overflow-hidden shrink-0">
-                            <%= image_tag meal.recipe.image.variant(resize_to_fill: [80, 80]), class: "w-full h-full object-cover", loading: "lazy", alt: meal.recipe.title %>
+                            <%= image_tag meal.recipe.image.variant(:thumbnail), class: "w-full h-full object-cover", loading: "lazy", alt: meal.recipe.title %>
                           </div>
                         <% end %>
                         <div class="flex-1 min-w-0">

--- a/app/views/accounts/recipes/_form.html.erb
+++ b/app/views/accounts/recipes/_form.html.erb
@@ -41,15 +41,54 @@
         <%= f.label :cook_time, "Cook time (minutes)", class: "block text-sm font-medium text-warm-700 mb-1" %>
         <%= f.number_field :cook_time, min: 0, class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500" %>
       </div>
-      <div class="md:col-span-2">
-        <%= f.label :image, "Recipe Photo", class: "block text-sm font-medium text-warm-700 mb-1" %>
+      <%# ── Cover Photo (drag-and-drop) ── %>
+      <div class="md:col-span-2" data-controller="image-upload">
+        <%= f.label :image, "Cover Photo", class: "block text-sm font-medium text-warm-700 mb-1" %>
         <% if @recipe.image.attached? %>
-          <div class="mb-3 relative inline-block">
-            <%= image_tag @recipe.image.variant(resize_to_fill: [300, 150]), class: "rounded-lg shadow-sm", alt: "Current photo" %>
+          <div class="mb-3" data-image-upload-target="preview">
+            <div class="relative inline-block group">
+              <%= image_tag @recipe.image.variant(:card), class: "rounded-xl shadow-sm max-h-48 object-cover", alt: "Current photo" %>
+            </div>
           </div>
         <% end %>
-        <%= f.file_field :image, accept: "image/*", class: "w-full text-sm text-warm-600 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-primary-50 file:text-primary-700 hover:file:bg-primary-100 file:cursor-pointer" %>
-        <p class="mt-1 text-sm text-warm-500">Upload a photo of the finished dish (optional)</p>
+        <div data-image-upload-target="dropZone"
+             data-action="dragenter->image-upload#dragenter dragleave->image-upload#dragleave dragover->image-upload#dragover drop->image-upload#drop click->image-upload#browse"
+             class="border-2 border-dashed border-warm-300 rounded-xl p-6 text-center cursor-pointer hover:border-primary-400 hover:bg-primary-50/30 transition-colors">
+          <div data-image-upload-target="placeholder" class="<%= @recipe.image.attached? ? 'hidden' : '' %>">
+            <svg class="w-10 h-10 text-warm-300 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+            </svg>
+            <p class="text-sm text-warm-500">Drag a photo here or <span class="text-primary-600 font-medium">browse</span></p>
+            <p class="text-xs text-warm-400 mt-1">JPEG, PNG, WebP, or GIF · Max 10MB</p>
+          </div>
+        </div>
+        <div data-image-upload-target="preview" class="<%= @recipe.image.attached? ? '' : 'hidden' %> mt-3"></div>
+        <%= f.file_field :image, accept: "image/jpeg,image/png,image/webp,image/gif", class: "hidden", data: { image_upload_target: "input", action: "image-upload#changed" } %>
+      </div>
+
+      <%# ── Additional Photos ── %>
+      <div class="md:col-span-2" data-controller="image-upload" data-image-upload-multiple-value="true">
+        <label class="block text-sm font-medium text-warm-700 mb-1">Additional Photos <span class="font-normal text-warm-400">(optional)</span></label>
+        <% if @recipe.persisted? && @recipe.images.attached? %>
+          <div class="flex flex-wrap gap-2 mb-3">
+            <% @recipe.images.each do |img| %>
+              <div class="relative group">
+                <%= image_tag img.variant(:thumbnail), class: "w-20 h-20 rounded-lg object-cover shadow-sm", alt: "Recipe photo" %>
+                <%= button_to recipe_path(@recipe, purge_image_id: img.id), method: :patch, class: "absolute -top-1.5 -right-1.5 w-5 h-5 bg-red-500 text-white rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity shadow-sm hover:bg-red-600", data: { turbo_confirm: "Remove this photo?" } do %>
+                  <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+        <div data-image-upload-target="dropZone"
+             data-action="dragenter->image-upload#dragenter dragleave->image-upload#dragleave dragover->image-upload#dragover drop->image-upload#drop click->image-upload#browse"
+             class="border-2 border-dashed border-warm-300 rounded-xl p-4 text-center cursor-pointer hover:border-primary-400 hover:bg-primary-50/30 transition-colors">
+          <p class="text-sm text-warm-500">Drag photos here or <span class="text-primary-600 font-medium">browse</span></p>
+          <p class="text-xs text-warm-400 mt-0.5">Step-by-step photos, plating variations, etc.</p>
+        </div>
+        <div data-image-upload-target="preview" class="hidden flex flex-wrap gap-2 mt-3"></div>
+        <%= f.file_field :images, multiple: true, accept: "image/jpeg,image/png,image/webp,image/gif", class: "hidden", data: { image_upload_target: "input", action: "image-upload#changed" } %>
       </div>
     </div>
   </div>

--- a/app/views/accounts/recipes/_recipe_card.html.erb
+++ b/app/views/accounts/recipes/_recipe_card.html.erb
@@ -2,7 +2,7 @@
     data: { controller: "recipe-card", recipe_card_index_value: index } do %>
   <div class="relative h-40 overflow-hidden">
     <% if recipe.image.attached? %>
-      <%= image_tag recipe.image.variant(resize_to_fill: [600, 300]),
+      <%= image_tag recipe.image.variant(:card),
           class: "w-full h-full object-cover recipe-card-image",
           loading: "lazy", alt: recipe.title %>
       <div class="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent"></div>

--- a/app/views/accounts/recipes/show.html.erb
+++ b/app/views/accounts/recipes/show.html.erb
@@ -8,6 +8,19 @@
 
   <div class="bg-white rounded-lg shadow overflow-hidden">
     <%= recipe_show_banner(@recipe) %>
+
+    <% if @recipe.images.any? %>
+      <div class="p-4 border-b border-warm-200 bg-warm-50">
+        <div class="flex gap-3 overflow-x-auto pb-2 snap-x snap-mandatory">
+          <% @recipe.images.each do |img| %>
+            <div class="snap-start shrink-0">
+              <%= image_tag img.variant(:card), class: "h-24 w-32 rounded-lg object-cover shadow-sm", loading: "lazy" %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+
     <div class="p-6 border-b border-warm-200">
       <div class="flex justify-between items-start">
         <div>

--- a/db/migrate/20260227204559_change_active_storage_attachments_record_id_to_string.rb
+++ b/db/migrate/20260227204559_change_active_storage_attachments_record_id_to_string.rb
@@ -1,0 +1,9 @@
+class ChangeActiveStorageAttachmentsRecordIdToString < ActiveRecord::Migration[8.1]
+  def up
+    change_column :active_storage_attachments, :record_id, :string, null: false
+  end
+
+  def down
+    change_column :active_storage_attachments, :record_id, :bigint, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_26_042020) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_27_204559) do
   create_table "access_tokens", id: :string, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "expires_at"
@@ -78,7 +78,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_26_042020) do
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.string "name", null: false
-    t.bigint "record_id", null: false
+    t.string "record_id", null: false
     t.string "record_type", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true

--- a/test/fixtures/files/recipe_with_jsonld.html
+++ b/test/fixtures/files/recipe_with_jsonld.html
@@ -50,6 +50,7 @@
       "fiberContent": "0g",
       "sodiumContent": "280mg"
     },
+    "image": "https://example.com/images/salmon.jpg",
     "url": "https://example.com/keto-garlic-butter-salmon"
   }
   </script>

--- a/test/models/recipe_test.rb
+++ b/test/models/recipe_test.rb
@@ -185,6 +185,97 @@ class RecipeTest < ActiveSupport::TestCase
     assert recipe.image.attached?
   end
 
+  test "can have multiple attached images" do
+    recipe = recipes(:one)
+    assert_respond_to recipe, :images
+
+    # Create attachment directly
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new("fake"), filename: "test.jpg", content_type: "image/jpeg"
+    )
+    ActiveStorage::Attachment.create!(
+      name: "images", record: recipe, blob: blob
+    )
+    assert_equal 1, recipe.reload.images.count
+
+    blob2 = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new("fake2"), filename: "test2.png", content_type: "image/png"
+    )
+    ActiveStorage::Attachment.create!(
+      name: "images", record: recipe, blob: blob2
+    )
+    assert_equal 2, recipe.reload.images.count
+  end
+
+  test "image defines named variants" do
+    recipe = recipes(:one)
+    recipe.image.attach(
+      io: StringIO.new("fake image data"),
+      filename: "test.jpg",
+      content_type: "image/jpeg"
+    )
+    assert recipe.image.variant(:thumbnail)
+    assert recipe.image.variant(:card)
+    assert recipe.image.variant(:full)
+  end
+
+  test "rejects image with invalid content type" do
+    recipe = recipes(:one)
+    recipe.image.attach(
+      io: StringIO.new("not an image"),
+      filename: "test.txt",
+      content_type: "text/plain"
+    )
+    assert_not recipe.valid?
+    assert_includes recipe.errors[:image], "must be a JPEG, PNG, WebP, or GIF file"
+  end
+
+  test "rejects image exceeding 10MB" do
+    recipe = recipes(:one)
+    recipe.image.attach(
+      io: StringIO.new("x" * (11 * 1024 * 1024)),
+      filename: "huge.jpg",
+      content_type: "image/jpeg"
+    )
+    assert_not recipe.valid?
+    assert_includes recipe.errors[:image], "must be less than 10MB"
+  end
+
+  test "accepts valid image types" do
+    recipe = recipes(:one)
+    %w[image/jpeg image/png image/webp image/gif].each do |type|
+      recipe.image.attach(
+        io: StringIO.new("fake"),
+        filename: "test.#{type.split('/').last}",
+        content_type: type
+      )
+      recipe.valid?
+      assert_empty recipe.errors[:image], "Expected #{type} to be accepted"
+    end
+  end
+
+  test "rejects additional images with invalid content type" do
+    recipe = recipes(:one)
+    recipe.images.attach(
+      io: StringIO.new("not an image"),
+      filename: "bad.txt",
+      content_type: "text/plain"
+    )
+    assert_not recipe.valid?
+    assert_includes recipe.errors[:images], "must be a JPEG, PNG, WebP, or GIF file"
+  end
+
+  test "rejects additional images exceeding 10MB" do
+    recipe = recipes(:one)
+    recipe.images.attach(
+      io: StringIO.new("x" * (11 * 1024 * 1024)),
+      filename: "huge.jpg",
+      content_type: "image/jpeg"
+    )
+    assert_not recipe.valid?
+    assert_includes recipe.errors[:images], "must be less than 10MB"
+  end
+
   test "to_meal_planning_response includes tags" do
     recipe = recipes(:one)
     response = recipe.to_meal_planning_response

--- a/test/services/recipe_import/json_ld_parser_test.rb
+++ b/test/services/recipe_import/json_ld_parser_test.rb
@@ -97,6 +97,37 @@ class RecipeImport::JsonLdParserTest < ActiveSupport::TestCase
     assert_equal "Step one", result[:instructions].first[:instruction]
   end
 
+  test "extracts image URL as string" do
+    result = RecipeImport::JsonLdParser.new(fixture_html("recipe_with_jsonld.html")).parse
+    assert_equal "https://example.com/images/salmon.jpg", result[:image_url]
+  end
+
+  test "extracts image URL from ImageObject hash" do
+    html = <<~HTML
+      <html><head>
+      <script type="application/ld+json">
+      {"@type":"Recipe","name":"Test","image":{"@type":"ImageObject","url":"https://example.com/photo.jpg"},"recipeIngredient":["water"],"recipeInstructions":["cook"]}
+      </script>
+      </head><body></body></html>
+    HTML
+
+    result = RecipeImport::JsonLdParser.new(html).parse
+    assert_equal "https://example.com/photo.jpg", result[:image_url]
+  end
+
+  test "extracts image URL from array" do
+    html = <<~HTML
+      <html><head>
+      <script type="application/ld+json">
+      {"@type":"Recipe","name":"Test","image":["https://example.com/1.jpg","https://example.com/2.jpg"],"recipeIngredient":["water"],"recipeInstructions":["cook"]}
+      </script>
+      </head><body></body></html>
+    HTML
+
+    result = RecipeImport::JsonLdParser.new(html).parse
+    assert_equal "https://example.com/1.jpg", result[:image_url]
+  end
+
   test "handles invalid JSON gracefully" do
     html = <<~HTML
       <html><head>


### PR DESCRIPTION
## Summary

- Adds cover photo (`has_one_attached :image`) and additional photos (`has_many_attached :images`) to recipes with named variants (`:thumbnail` 200x200, `:card` 400x300, `:full` 1200x800)
- Builds a Stimulus drag-and-drop image upload controller with live preview, file type/size validation, and support for both single and multiple file modes
- Extracts image URLs from JSON-LD during recipe URL import and auto-attaches them as cover photos
- Fixes `active_storage_attachments.record_id` column type from `bigint` to `string` to support UUID primary keys

## Changes

- `app/models/recipe.rb` — `has_one_attached :image` with named variants, `has_many_attached :images`, content type + file size validations
- `app/javascript/controllers/image_upload_controller.js` — New Stimulus controller: drag-and-drop, click-to-browse, FileReader live preview, single/multiple modes
- `app/views/accounts/recipes/_form.html.erb` — Drag-and-drop upload zones for cover photo and additional photos
- `app/views/accounts/recipes/show.html.erb` — Additional images gallery (horizontal scroll)
- `app/controllers/accounts/recipes_controller.rb` — Permit `images: []`, `purge_image_id` handling, `attach_imported_image` for URL imports
- `app/services/recipe_import/json_ld_parser.rb` — Extract `image` field from JSON-LD (string, ImageObject hash, array)
- `app/helpers/recipes_helper.rb`, `_recipe_card.html.erb`, `_calendar_cell.html.erb`, `show.html.erb` — Replace inline `resize_to_fill` with named variants
- `db/migrate/...change_active_storage_attachments_record_id_to_string.rb` — Fix UUID compatibility

## Testing

- 851 tests, 0 failures, 0 errors
- Rubocop: no offenses in changed files
- Brakeman: 0 warnings
- bundler-audit / importmap audit: clean
- New tests cover: multiple attached images, named variants, content type rejection, file size rejection, valid types acceptance, JSON-LD image URL extraction (string, hash, array formats)

Closes #24