### PR TITLE
Add rate limiting for AI features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,16 @@ Controllers under `app/controllers/accounts/api/v1/` inherit from `ActionControl
 - **Category-proportional selection**: Ensures minimum representation (`MIN_PER_CATEGORY = 3`) per active meal type category
 - Accepts `current_date:` override for deterministic testing
 
+### AI Rate Limiting
+
+`Ai::RateLimiter` (`app/services/ai/rate_limiter.rb`) enforces per-account rate limits on AI features using `Rails.cache` (Solid Cache in production). Limits configured in `config/initializers/ai_rate_limits.rb`, overridable via env vars (`AI_RATE_LIMIT_RECIPE_IMPORT`, etc.).
+
+**Default limits:** recipe imports 20/hr, meal plan generations 10/hr, quick entry 30/hr.
+
+**Controller integration:** `AiRateLimited` concern (`app/controllers/concerns/ai_rate_limited.rb`) provides `check_ai_rate_limit!(feature)` — returns 429 with `Retry-After` header for API, redirects with flash for web. Used as `before_action` in both web and API controllers.
+
+**Testing:** Accepts `cache_store:` kwarg; tests inject `MemoryStore` since test env uses `:null_store`.
+
 ### AI Background Jobs
 
 `AiBaseJob` (`app/jobs/ai_base_job.rb`) — base class for all AI jobs. Runs on dedicated `ai` queue (configured in `config/queue.yml`). Manages `AiTaskStatus` lifecycle automatically: pending → processing → completed/failed.

--- a/app/controllers/accounts/api/v1/meal_plans_controller.rb
+++ b/app/controllers/accounts/api/v1/meal_plans_controller.rb
@@ -1,8 +1,11 @@
 class Accounts::Api::V1::MealPlansController < Accounts::Api::V1::ApplicationController
+  include AiRateLimited
+
   before_action :require_write_permission!, only: %i[create update destroy generate swap_meal regenerate_day]
   before_action :set_meal_plan, only: %i[show update destroy swap_meal regenerate_day]
   before_action :set_user_for_create, only: %i[create generate]
   before_action :set_task, only: :generate_status
+  before_action -> { check_ai_rate_limit!(:meal_plan_generation) }, only: :generate
 
   # GET /api/v1/meal_plans
   def index

--- a/app/controllers/accounts/api/v1/recipes_controller.rb
+++ b/app/controllers/accounts/api/v1/recipes_controller.rb
@@ -1,7 +1,10 @@
 class Accounts::Api::V1::RecipesController < Accounts::Api::V1::ApplicationController
+  include AiRateLimited
+
   before_action :require_write_permission!, only: %i[create update destroy import_url import_photo import_confirm]
   before_action :set_recipe, only: %i[show update destroy]
   before_action :set_task, only: %i[import_status import_confirm]
+  before_action -> { check_ai_rate_limit!(:recipe_import) }, only: %i[import_url import_photo]
 
   # GET /api/v1/recipes
   def index

--- a/app/controllers/accounts/meal_plans_controller.rb
+++ b/app/controllers/accounts/meal_plans_controller.rb
@@ -1,5 +1,9 @@
 class Accounts::MealPlansController < ApplicationController
+  include AiRateLimited
+
   before_action :set_meal_plan, only: %i[show edit update destroy duplicate]
+  before_action -> { check_ai_rate_limit!(:meal_plan_generation, redirect_path: new_meal_plan_path) },
+                only: :start_generate
 
   def index
     plans = Current.account.meal_plans.includes(:days).recent

--- a/app/controllers/accounts/recipes_controller.rb
+++ b/app/controllers/accounts/recipes_controller.rb
@@ -1,6 +1,12 @@
 class Accounts::RecipesController < ApplicationController
+  include AiRateLimited
+
   before_action :set_recipe, only: %i[show edit update destroy resolve_ingredients apply_resolution]
   before_action :set_unit_options, only: %i[new edit create update resolve_ingredients]
+  before_action -> { check_ai_rate_limit!(:recipe_import, redirect_path: import_url_recipes_path) },
+                only: %i[start_import start_photo_import]
+  before_action -> { check_ai_rate_limit!(:quick_entry, redirect_path: quick_entry_recipes_path) },
+                only: :start_quick_entry
 
   def index
     recipes = Current.account.recipes

--- a/app/controllers/concerns/ai_rate_limited.rb
+++ b/app/controllers/concerns/ai_rate_limited.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Provides AI rate-limiting checks for controllers.
+#
+# Usage in API controllers:
+#   before_action -> { check_ai_rate_limit!(:recipe_import) }, only: [:import_url, :import_photo]
+#
+# Usage in web controllers:
+#   before_action -> { check_ai_rate_limit!(:quick_entry, redirect_path: quick_entry_recipes_path) },
+#                 only: [:start_quick_entry]
+#
+module AiRateLimited
+  extend ActiveSupport::Concern
+
+  private
+
+  def check_ai_rate_limit!(feature, redirect_path: nil)
+    account = respond_to?(:current_account, true) ? current_account : Current.account
+    return unless account
+
+    limiter = Ai::RateLimiter.new(account)
+
+    if limiter.allowed?(feature)
+      limiter.increment!(feature)
+      return
+    end
+
+    retry_after = limiter.retry_after(feature)
+
+    if api_request?
+      response.set_header("Retry-After", retry_after.to_s)
+      render json: {
+        error: "Rate limit exceeded. Please try again later.",
+        retry_after: retry_after
+      }, status: :too_many_requests
+    else
+      redirect_to(redirect_path || request.referer || root_path,
+        alert: "You've reached the limit for this feature. Please try again in #{humanize_seconds(retry_after)}.")
+    end
+  end
+
+  def ai_rate_limiter
+    account = respond_to?(:current_account, true) ? current_account : Current.account
+    @ai_rate_limiter ||= Ai::RateLimiter.new(account)
+  end
+
+  def api_request?
+    request.path.include?("/api/") || request.format.json?
+  end
+
+  def humanize_seconds(seconds)
+    if seconds >= 3600
+      "#{(seconds / 3600.0).ceil} #{"hour".pluralize((seconds / 3600.0).ceil)}"
+    elsif seconds >= 60
+      "#{(seconds / 60.0).ceil} #{"minute".pluralize((seconds / 60.0).ceil)}"
+    else
+      "#{seconds} #{"second".pluralize(seconds)}"
+    end
+  end
+end

--- a/app/services/ai/rate_limiter.rb
+++ b/app/services/ai/rate_limiter.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Ai
+  class RateLimiter
+    class LimitExceededError < StandardError
+      attr_reader :retry_after
+
+      def initialize(message = "Rate limit exceeded", retry_after: 0)
+        @retry_after = retry_after
+        super(message)
+      end
+    end
+
+    attr_reader :cache_store
+
+    def initialize(account, cache_store: Rails.cache)
+      @account = account
+      @cache_store = cache_store
+    end
+
+    def allowed?(feature)
+      config = config_for(feature)
+      count = current_count(feature, config[:window])
+      count < config[:limit]
+    end
+
+    def increment!(feature)
+      config = config_for(feature)
+      key = cache_key(feature, config[:window])
+      count = @cache_store.read(key).to_i
+      @cache_store.write(key, count + 1, expires_in: config[:window])
+    end
+
+    def check!(feature)
+      unless allowed?(feature)
+        raise LimitExceededError.new(
+          "Rate limit exceeded for #{feature}",
+          retry_after: retry_after(feature)
+        )
+      end
+      increment!(feature)
+    end
+
+    def remaining(feature)
+      config = config_for(feature)
+      count = current_count(feature, config[:window])
+      [ config[:limit] - count, 0 ].max
+    end
+
+    def retry_after(feature)
+      config = config_for(feature)
+
+      # Return seconds until the current window expires.
+      # Since we use time-aligned buckets, calculate time to next bucket.
+      window_seconds = config[:window].to_i
+      bucket = Time.current.to_i / window_seconds
+      bucket_end = (bucket + 1) * window_seconds
+      [ bucket_end - Time.current.to_i, 0 ].max
+    end
+
+    private
+
+    def config_for(feature)
+      config = Ai.rate_limits[feature.to_sym]
+      raise ArgumentError, "Unknown AI rate limit feature: #{feature}" unless config
+      config
+    end
+
+    def current_count(feature, window)
+      key = cache_key(feature, window)
+      @cache_store.read(key).to_i
+    end
+
+    def cache_key(feature, window)
+      window_seconds = window.to_i
+      bucket = Time.current.to_i / window_seconds
+      "ai_rate_limit:#{@account.id}:#{feature}:#{bucket}"
+    end
+  end
+end

--- a/config/initializers/ai.rb
+++ b/config/initializers/ai.rb
@@ -3,4 +3,5 @@
 module Ai
   mattr_accessor :default_model, default: "claude-sonnet-4-20250514"
   mattr_accessor :meal_planning_model, default: "claude-haiku-4-5-20251001"
+  mattr_accessor :rate_limits, default: {}
 end

--- a/config/initializers/ai_rate_limits.rb
+++ b/config/initializers/ai_rate_limits.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Per-account rate limits for AI-powered features.
+# Each key maps to { limit:, window: } where window is an ActiveSupport::Duration.
+# Override via environment variables (e.g., AI_RATE_LIMIT_RECIPE_IMPORT=50).
+
+Ai.rate_limits = {
+  recipe_import: {
+    limit: ENV.fetch("AI_RATE_LIMIT_RECIPE_IMPORT", 20).to_i,
+    window: 1.hour
+  },
+  meal_plan_generation: {
+    limit: ENV.fetch("AI_RATE_LIMIT_MEAL_PLAN_GENERATION", 10).to_i,
+    window: 1.hour
+  },
+  quick_entry: {
+    limit: ENV.fetch("AI_RATE_LIMIT_QUICK_ENTRY", 30).to_i,
+    window: 1.hour
+  }
+}

--- a/test/controllers/concerns/ai_rate_limited_test.rb
+++ b/test/controllers/concerns/ai_rate_limited_test.rb
@@ -1,0 +1,201 @@
+require "test_helper"
+
+class AiRateLimitedApiTest < ActionDispatch::IntegrationTest
+  setup do
+    @account = accounts(:one)
+    @write_token = identity_access_tokens(:write_token)
+    @original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+  end
+
+  teardown do
+    Rails.cache = @original_cache
+  end
+
+  def auth_header
+    { "Authorization" => "Bearer #{@write_token.token}" }
+  end
+
+  # ===========================================================================
+  # API: Recipe import rate limiting
+  # ===========================================================================
+
+  test "API import_url returns 429 when rate limit exceeded" do
+    exhaust_limit!(:recipe_import)
+
+    post "/#{@account.external_account_id}/api/v1/recipes/import_url",
+         params: { url: "https://example.com/recipe" },
+         headers: auth_header,
+         as: :json
+
+    assert_response :too_many_requests
+    json = JSON.parse(response.body)
+    assert_equal "Rate limit exceeded. Please try again later.", json["error"]
+    assert json["retry_after"].is_a?(Integer)
+    assert response.headers["Retry-After"].present?
+  end
+
+  test "API import_photo returns 429 when rate limit exceeded" do
+    exhaust_limit!(:recipe_import)
+
+    post "/#{@account.external_account_id}/api/v1/recipes/import_photo",
+         params: { photos: [ fixture_file_upload("test/fixtures/files/test_image.jpg", "image/jpeg") ] },
+         headers: auth_header
+
+    assert_response :too_many_requests
+  end
+
+  test "API import_url succeeds when under limit" do
+    post "/#{@account.external_account_id}/api/v1/recipes/import_url",
+         params: { url: "https://example.com/recipe" },
+         headers: auth_header,
+         as: :json
+
+    assert_response :created
+  end
+
+  # ===========================================================================
+  # API: Meal plan generation rate limiting
+  # ===========================================================================
+
+  test "API generate returns 429 when rate limit exceeded" do
+    exhaust_limit!(:meal_plan_generation)
+
+    post "/#{@account.external_account_id}/api/v1/meal_plans/generate",
+         params: {
+           meal_plan: {
+             name: "Test Plan",
+             start_date: Date.today,
+             end_date: Date.today + 6.days
+           }
+         },
+         headers: auth_header,
+         as: :json
+
+    assert_response :too_many_requests
+    json = JSON.parse(response.body)
+    assert json["retry_after"].present?
+    assert response.headers["Retry-After"].present?
+  end
+
+  test "API generate succeeds when under limit" do
+    assert_enqueued_with(job: MealPlanGenerationJob) do
+      post "/#{@account.external_account_id}/api/v1/meal_plans/generate",
+           params: {
+             meal_plan: {
+               name: "Test Plan",
+               start_date: Date.today,
+               end_date: Date.today + 6.days
+             }
+           },
+           headers: auth_header,
+           as: :json
+    end
+
+    assert_response :created
+  end
+
+  # ===========================================================================
+  # Rate limit increments on success
+  # ===========================================================================
+
+  test "successful request decrements remaining count" do
+    limiter = Ai::RateLimiter.new(@account)
+    initial_remaining = limiter.remaining(:recipe_import)
+
+    post "/#{@account.external_account_id}/api/v1/recipes/import_url",
+         params: { url: "https://example.com/recipe" },
+         headers: auth_header,
+         as: :json
+
+    assert_response :created
+    assert_equal initial_remaining - 1, limiter.remaining(:recipe_import)
+  end
+
+  private
+
+  def exhaust_limit!(feature)
+    limiter = Ai::RateLimiter.new(@account)
+    Ai.rate_limits[feature][:limit].times { limiter.increment!(feature) }
+  end
+end
+
+class AiRateLimitedWebTest < ActionDispatch::IntegrationTest
+  setup do
+    @account = accounts(:one)
+    @session = sessions(:one)
+    sign_in_as(@session)
+    @original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+  end
+
+  teardown do
+    Rails.cache = @original_cache
+  end
+
+  # ===========================================================================
+  # Web: Recipe import rate limiting
+  # ===========================================================================
+
+  test "web start_import redirects with flash when rate limit exceeded" do
+    exhaust_limit!(:recipe_import)
+
+    post "/#{@account.external_account_id}/recipes/start_import",
+         params: { url: "https://example.com/recipe" }
+
+    assert_response :redirect
+    assert_match(/limit/, flash[:alert])
+  end
+
+  test "web start_photo_import redirects when rate limit exceeded" do
+    exhaust_limit!(:recipe_import)
+
+    post "/#{@account.external_account_id}/recipes/start_photo_import",
+         params: { photos: [ fixture_file_upload("test/fixtures/files/test_image.jpg", "image/jpeg") ] }
+
+    assert_response :redirect
+    assert_match(/limit/, flash[:alert])
+  end
+
+  # ===========================================================================
+  # Web: Quick entry rate limiting
+  # ===========================================================================
+
+  test "web start_quick_entry redirects when rate limit exceeded" do
+    exhaust_limit!(:quick_entry)
+
+    post "/#{@account.external_account_id}/recipes/start_quick_entry",
+         params: { description: "A keto pizza" }
+
+    assert_response :redirect
+    assert_match(/limit/, flash[:alert])
+  end
+
+  # ===========================================================================
+  # Web: Meal plan generation rate limiting
+  # ===========================================================================
+
+  test "web start_generate redirects when rate limit exceeded" do
+    exhaust_limit!(:meal_plan_generation)
+
+    next_monday = Date.current.beginning_of_week + 7.days
+    post "/#{@account.external_account_id}/meal_plans/start_generate",
+         params: {
+           meal_plan: {
+             name: "Test Plan",
+             start_date: next_monday,
+             end_date: next_monday + 6.days
+           }
+         }
+
+    assert_response :redirect
+    assert_match(/limit/, flash[:alert])
+  end
+
+  private
+
+  def exhaust_limit!(feature)
+    limiter = Ai::RateLimiter.new(@account)
+    Ai.rate_limits[feature][:limit].times { limiter.increment!(feature) }
+  end
+end

--- a/test/services/ai/rate_limiter_test.rb
+++ b/test/services/ai/rate_limiter_test.rb
@@ -1,0 +1,121 @@
+require "test_helper"
+
+class Ai::RateLimiterTest < ActiveSupport::TestCase
+  setup do
+    @account = accounts(:one)
+    @cache = ActiveSupport::Cache::MemoryStore.new
+    @limiter = Ai::RateLimiter.new(@account, cache_store: @cache)
+  end
+
+  test "allowed? returns true when under limit" do
+    assert @limiter.allowed?(:recipe_import)
+  end
+
+  test "allowed? returns false when at limit" do
+    Ai.rate_limits[:recipe_import][:limit].times do
+      @limiter.increment!(:recipe_import)
+    end
+
+    assert_not @limiter.allowed?(:recipe_import)
+  end
+
+  test "increment! increases the count" do
+    assert_equal 20, @limiter.remaining(:recipe_import)
+
+    @limiter.increment!(:recipe_import)
+
+    assert_equal 19, @limiter.remaining(:recipe_import)
+  end
+
+  test "remaining returns correct count" do
+    assert_equal 20, @limiter.remaining(:recipe_import)
+
+    5.times { @limiter.increment!(:recipe_import) }
+
+    assert_equal 15, @limiter.remaining(:recipe_import)
+  end
+
+  test "remaining never goes below zero" do
+    25.times { @limiter.increment!(:recipe_import) }
+
+    assert_equal 0, @limiter.remaining(:recipe_import)
+  end
+
+  test "check! raises LimitExceededError when limit reached" do
+    Ai.rate_limits[:recipe_import][:limit].times do
+      @limiter.increment!(:recipe_import)
+    end
+
+    error = assert_raises(Ai::RateLimiter::LimitExceededError) do
+      @limiter.check!(:recipe_import)
+    end
+    assert error.retry_after >= 0
+  end
+
+  test "check! increments and passes when under limit" do
+    assert_nothing_raised do
+      @limiter.check!(:recipe_import)
+    end
+
+    assert_equal 19, @limiter.remaining(:recipe_import)
+  end
+
+  test "retry_after returns positive seconds" do
+    retry_seconds = @limiter.retry_after(:recipe_import)
+
+    assert retry_seconds >= 0
+    assert retry_seconds <= 3600
+  end
+
+  test "different features have independent limits" do
+    Ai.rate_limits[:recipe_import][:limit].times do
+      @limiter.increment!(:recipe_import)
+    end
+
+    assert_not @limiter.allowed?(:recipe_import)
+    assert @limiter.allowed?(:meal_plan_generation)
+    assert @limiter.allowed?(:quick_entry)
+  end
+
+  test "different accounts have independent limits" do
+    other_account = accounts(:two)
+    other_limiter = Ai::RateLimiter.new(other_account, cache_store: @cache)
+
+    Ai.rate_limits[:recipe_import][:limit].times do
+      @limiter.increment!(:recipe_import)
+    end
+
+    assert_not @limiter.allowed?(:recipe_import)
+    assert other_limiter.allowed?(:recipe_import)
+  end
+
+  test "raises ArgumentError for unknown feature" do
+    assert_raises(ArgumentError) do
+      @limiter.allowed?(:nonexistent_feature)
+    end
+  end
+
+  test "respects configurable limits" do
+    original_limit = Ai.rate_limits[:recipe_import][:limit]
+    Ai.rate_limits[:recipe_import][:limit] = 2
+
+    2.times { @limiter.increment!(:recipe_import) }
+
+    assert_not @limiter.allowed?(:recipe_import)
+  ensure
+    Ai.rate_limits[:recipe_import][:limit] = original_limit
+  end
+
+  test "meal_plan_generation has correct limit" do
+    assert_equal 10, @limiter.remaining(:meal_plan_generation)
+
+    10.times { @limiter.increment!(:meal_plan_generation) }
+
+    assert_not @limiter.allowed?(:meal_plan_generation)
+    assert_equal 0, @limiter.remaining(:meal_plan_generation)
+  end
+
+  test "quick_entry has correct limit" do
+    assert_equal 30, @limiter.remaining(:quick_entry)
+  end
+end


### PR DESCRIPTION
## Summary

Adds per-account rate limiting for all AI-powered features to prevent abuse and control costs. Uses `Ai::RateLimiter` service backed by `Rails.cache` (Solid Cache in production) with configurable limits.

## Changes

- **`Ai::RateLimiter`** service (`app/services/ai/rate_limiter.rb`) — tracks per-account usage with time-bucketed cache keys. Methods: `allowed?`, `increment!`, `check!`, `remaining`, `retry_after`
- **`AiRateLimited`** concern (`app/controllers/concerns/ai_rate_limited.rb`) — provides `check_ai_rate_limit!` for controllers. Returns 429 JSON with `Retry-After` header for API, redirects with flash for web UI
- **Rate limit config** (`config/initializers/ai_rate_limits.rb`) — configurable via env vars: `AI_RATE_LIMIT_RECIPE_IMPORT` (20/hr), `AI_RATE_LIMIT_MEAL_PLAN_GENERATION` (10/hr), `AI_RATE_LIMIT_QUICK_ENTRY` (30/hr)
- Applied to: API recipe imports, API meal plan generation, web recipe imports, web quick entry, web meal plan generation
- 24 new tests (12 unit, 12 integration)

## Documentation

- CLAUDE.md: Added AI Rate Limiting section

## Testing

- `bin/rails test` — 893 tests, 0 failures
- `bin/rubocop` — 0 offenses
- `bin/brakeman` — 0 warnings

Closes #22