### PR TITLE
Redesign New Meal Plan form as 3-step wizard

### DIFF
--- a/app/controllers/accounts/meal_plans_controller.rb
+++ b/app/controllers/accounts/meal_plans_controller.rb
@@ -23,10 +23,8 @@ class Accounts::MealPlansController < ApplicationController
     next_monday = Date.current.beginning_of_week + 7.days
     @meal_plan = Current.account.meal_plans.build(
       start_date: next_monday,
-      end_date: next_monday + 6.days,
-      name: "Week of #{next_monday.strftime('%b %-d, %Y')}"
+      end_date: next_monday + 6.days
     )
-    @available_profiles = Current.account.dietary_profiles.active.order(:name)
   end
 
   def create

--- a/app/javascript/controllers/ai_generate_controller.js
+++ b/app/javascript/controllers/ai_generate_controller.js
@@ -13,27 +13,39 @@ export default class extends Controller {
     this.active = !this.active
 
     if (this.active) {
-      this.panelTarget.classList.remove("hidden")
-      this.chevronTarget.style.transform = "rotate(180deg)"
-      this.toggleButtonTarget.classList.remove("border-dashed", "border-warm-300")
-      this.toggleButtonTarget.classList.add("border-solid", "border-primary-400", "bg-primary-50/50")
-      this.iconWrapTarget.classList.remove("bg-warm-100")
-      this.iconWrapTarget.classList.add("bg-primary-100")
-      this.iconTarget.classList.remove("text-warm-500")
-      this.iconTarget.classList.add("text-primary-600")
-      this.manualSubmitTarget.classList.add("hidden")
-      this.aiSubmitTarget.classList.remove("hidden")
+      if (this.hasPanelTarget) this.panelTarget.classList.remove("hidden")
+      if (this.hasChevronTarget) this.chevronTarget.style.transform = "rotate(180deg)"
+      if (this.hasToggleButtonTarget) {
+        this.toggleButtonTarget.classList.remove("border-dashed", "border-warm-300")
+        this.toggleButtonTarget.classList.add("border-solid", "border-primary-400", "bg-primary-50/50")
+      }
+      if (this.hasIconWrapTarget) {
+        this.iconWrapTarget.classList.remove("bg-warm-100")
+        this.iconWrapTarget.classList.add("bg-primary-100")
+      }
+      if (this.hasIconTarget) {
+        this.iconTarget.classList.remove("text-warm-500")
+        this.iconTarget.classList.add("text-primary-600")
+      }
+      if (this.hasManualSubmitTarget) this.manualSubmitTarget.classList.add("hidden")
+      if (this.hasAiSubmitTarget) this.aiSubmitTarget.classList.remove("hidden")
     } else {
-      this.panelTarget.classList.add("hidden")
-      this.chevronTarget.style.transform = ""
-      this.toggleButtonTarget.classList.add("border-dashed", "border-warm-300")
-      this.toggleButtonTarget.classList.remove("border-solid", "border-primary-400", "bg-primary-50/50")
-      this.iconWrapTarget.classList.add("bg-warm-100")
-      this.iconWrapTarget.classList.remove("bg-primary-100")
-      this.iconTarget.classList.add("text-warm-500")
-      this.iconTarget.classList.remove("text-primary-600")
-      this.manualSubmitTarget.classList.remove("hidden")
-      this.aiSubmitTarget.classList.add("hidden")
+      if (this.hasPanelTarget) this.panelTarget.classList.add("hidden")
+      if (this.hasChevronTarget) this.chevronTarget.style.transform = ""
+      if (this.hasToggleButtonTarget) {
+        this.toggleButtonTarget.classList.add("border-dashed", "border-warm-300")
+        this.toggleButtonTarget.classList.remove("border-solid", "border-primary-400", "bg-primary-50/50")
+      }
+      if (this.hasIconWrapTarget) {
+        this.iconWrapTarget.classList.add("bg-warm-100")
+        this.iconWrapTarget.classList.remove("bg-primary-100")
+      }
+      if (this.hasIconTarget) {
+        this.iconTarget.classList.add("text-warm-500")
+        this.iconTarget.classList.remove("text-primary-600")
+      }
+      if (this.hasManualSubmitTarget) this.manualSubmitTarget.classList.remove("hidden")
+      if (this.hasAiSubmitTarget) this.aiSubmitTarget.classList.add("hidden")
     }
   }
 

--- a/app/javascript/controllers/meal_plan_wizard_controller.js
+++ b/app/javascript/controllers/meal_plan_wizard_controller.js
@@ -1,0 +1,324 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    currentStep: { type: Number, default: 1 },
+    selectedDate: String,
+    selectedDays: { type: Number, default: 7 },
+    viewYear: Number,
+    viewMonth: Number,
+    todayIso: String,
+    createUrl: String,
+    generateUrl: String
+  }
+
+  static targets = [
+    "step", "stepIndicator",
+    "calendarGrid", "calendarTitle", "prevMonth",
+    "durationButton", "customDaysInput", "customDaysLink",
+    "selectedDateText", "summaryText",
+    "nameField", "startDateField", "endDateField",
+    "backButton", "nextButton", "navigationFooter"
+  ]
+
+  connect() {
+    const today = new Date()
+    this.viewYearValue = today.getFullYear()
+    this.viewMonthValue = today.getMonth()
+    this.todayIsoValue = this.formatDate(today)
+
+    this.renderCalendar()
+    this.updateStepVisibility()
+  }
+
+  // === Calendar rendering ===
+
+  renderCalendar() {
+    const year = this.viewYearValue
+    const month = this.viewMonthValue
+    const firstDay = new Date(year, month, 1)
+    const lastDay = new Date(year, month + 1, 0)
+    const startPad = firstDay.getDay() // 0=Sun
+
+    const monthNames = ["January", "February", "March", "April", "May", "June",
+      "July", "August", "September", "October", "November", "December"]
+    this.calendarTitleTarget.textContent = `${monthNames[month]} ${year}`
+
+    // Hide prev arrow if viewing current month
+    const now = new Date()
+    if (year === now.getFullYear() && month === now.getMonth()) {
+      this.prevMonthTarget.classList.add("invisible")
+    } else {
+      this.prevMonthTarget.classList.remove("invisible")
+    }
+
+    let html = ""
+
+    // Blank padding for first row
+    for (let i = 0; i < startPad; i++) {
+      html += `<div></div>`
+    }
+
+    for (let d = 1; d <= lastDay.getDate(); d++) {
+      const date = new Date(year, month, d)
+      const iso = this.formatDate(date)
+      const isPast = iso < this.todayIsoValue
+      const isToday = iso === this.todayIsoValue
+      const isSelected = iso === this.selectedDateValue
+
+      let classes = "w-10 h-10 rounded-full text-sm font-medium flex items-center justify-center mx-auto transition-all duration-150 "
+
+      if (isSelected) {
+        classes += "bg-primary-600 text-white shadow-md scale-110"
+      } else if (isPast) {
+        classes += "text-warm-300 cursor-not-allowed"
+      } else if (isToday) {
+        classes += "ring-2 ring-primary-300 text-primary-700 hover:bg-primary-100 cursor-pointer"
+      } else {
+        classes += "text-warm-700 hover:bg-primary-100 cursor-pointer"
+      }
+
+      if (isPast && !isSelected) {
+        html += `<div><div class="${classes}">${d}</div></div>`
+      } else {
+        html += `<div><button type="button" class="${classes}" data-action="meal-plan-wizard#selectDate" data-date="${iso}">${d}</button></div>`
+      }
+    }
+
+    this.calendarGridTarget.innerHTML = html
+  }
+
+  prevMonthAction() {
+    if (this.viewMonthValue === 0) {
+      this.viewMonthValue = 11
+      this.viewYearValue--
+    } else {
+      this.viewMonthValue--
+    }
+    this.renderCalendar()
+  }
+
+  nextMonthAction() {
+    if (this.viewMonthValue === 11) {
+      this.viewMonthValue = 0
+      this.viewYearValue++
+    } else {
+      this.viewMonthValue++
+    }
+    this.renderCalendar()
+  }
+
+  selectDate(event) {
+    event.preventDefault()
+    this.selectedDateValue = event.currentTarget.dataset.date
+    this.renderCalendar()
+
+    // Auto-advance to step 2 after brief delay
+    setTimeout(() => {
+      this.currentStepValue = 2
+      this.updateStepVisibility()
+      this.updateDurationStep()
+    }, 200)
+  }
+
+  // === Duration selection ===
+
+  updateDurationStep() {
+    const formatted = this.formatDisplayDate(this.selectedDateValue)
+    if (this.hasSelectedDateTextTarget) {
+      this.selectedDateTextTarget.textContent = formatted
+    }
+    this.highlightDurationButtons()
+    this.computeEndDate()
+  }
+
+  selectDuration(event) {
+    event.preventDefault()
+    const days = parseInt(event.currentTarget.dataset.days)
+    this.selectedDaysValue = days
+    this.highlightDurationButtons()
+    this.computeEndDate()
+
+    // Hide custom input if showing
+    if (this.hasCustomDaysInputTarget) {
+      this.customDaysInputTarget.classList.add("hidden")
+      this.customDaysLinkTarget.classList.remove("hidden")
+    }
+  }
+
+  highlightDurationButtons() {
+    this.durationButtonTargets.forEach(btn => {
+      const days = parseInt(btn.dataset.days)
+      if (days === this.selectedDaysValue) {
+        btn.classList.remove("border-warm-200", "bg-white", "text-warm-700")
+        btn.classList.add("border-primary-500", "bg-primary-50", "text-primary-700", "ring-2", "ring-primary-200", "scale-105")
+      } else {
+        btn.classList.add("border-warm-200", "bg-white", "text-warm-700")
+        btn.classList.remove("border-primary-500", "bg-primary-50", "text-primary-700", "ring-2", "ring-primary-200", "scale-105")
+      }
+    })
+  }
+
+  showCustomDays(event) {
+    event.preventDefault()
+    this.customDaysLinkTarget.classList.add("hidden")
+    this.customDaysInputTarget.classList.remove("hidden")
+    this.customDaysInputTarget.querySelector("input").focus()
+  }
+
+  setCustomDays(event) {
+    let val = parseInt(event.currentTarget.value)
+    if (isNaN(val) || val < 1) val = 1
+    if (val > 30) val = 30
+    this.selectedDaysValue = val
+
+    // Deselect preset buttons
+    this.durationButtonTargets.forEach(btn => {
+      btn.classList.add("border-warm-200", "bg-white", "text-warm-700")
+      btn.classList.remove("border-primary-500", "bg-primary-50", "text-primary-700", "ring-2", "ring-primary-200", "scale-105")
+    })
+
+    this.computeEndDate()
+  }
+
+  computeEndDate() {
+    if (!this.selectedDateValue) return
+    const start = new Date(this.selectedDateValue + "T00:00:00")
+    const end = new Date(start)
+    end.setDate(end.getDate() + this.selectedDaysValue - 1)
+    this.endDateIso = this.formatDate(end)
+
+    if (this.hasSummaryTextTarget) {
+      const startDisplay = this.formatDisplayDate(this.selectedDateValue)
+      const endDisplay = this.formatDisplayDate(this.endDateIso)
+      this.summaryTextTarget.textContent = `${startDisplay} \u2013 ${endDisplay} (${this.selectedDaysValue} days)`
+    }
+  }
+
+  // === Step navigation ===
+
+  nextStep() {
+    if (this.currentStepValue < 3) {
+      this.currentStepValue++
+      this.updateStepVisibility()
+      if (this.currentStepValue === 2) this.updateDurationStep()
+      if (this.currentStepValue === 3) this.computeEndDate()
+    }
+  }
+
+  prevStep() {
+    if (this.currentStepValue > 1) {
+      this.currentStepValue--
+      this.updateStepVisibility()
+    }
+  }
+
+  updateStepVisibility() {
+    const step = this.currentStepValue
+
+    this.stepTargets.forEach((el, idx) => {
+      if (idx + 1 === step) {
+        el.classList.remove("hidden")
+      } else {
+        el.classList.add("hidden")
+      }
+    })
+
+    // Update step indicators
+    this.stepIndicatorTargets.forEach((el, idx) => {
+      const stepNum = idx + 1
+      const circle = el.querySelector("[data-circle]")
+      const label = el.querySelector("[data-label]")
+      const line = el.querySelector("[data-line]")
+
+      if (stepNum < step) {
+        // Completed
+        if (circle) {
+          circle.className = "w-8 h-8 rounded-full flex items-center justify-center bg-primary-600 text-white text-sm font-bold"
+          circle.innerHTML = '<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>'
+        }
+        if (label) label.className = "text-xs font-medium text-primary-600 mt-1"
+        if (line) line.className = "h-0.5 bg-primary-600 flex-1"
+      } else if (stepNum === step) {
+        // Current
+        if (circle) {
+          circle.className = "w-8 h-8 rounded-full flex items-center justify-center bg-primary-600 text-white text-sm font-bold"
+          circle.textContent = stepNum
+        }
+        if (label) label.className = "text-xs font-medium text-primary-700 mt-1"
+        if (line) line.className = "h-0.5 bg-warm-200 flex-1"
+      } else {
+        // Future
+        if (circle) {
+          circle.className = "w-8 h-8 rounded-full flex items-center justify-center bg-warm-100 text-warm-400 text-sm font-medium"
+          circle.textContent = stepNum
+        }
+        if (label) label.className = "text-xs font-medium text-warm-400 mt-1"
+        if (line) line.className = "h-0.5 bg-warm-200 flex-1"
+      }
+    })
+
+    // Navigation footer: show on steps 1-2, hide on 3
+    if (this.hasNavigationFooterTarget) {
+      this.navigationFooterTarget.classList.toggle("hidden", step === 3)
+    }
+
+    // Back button visibility
+    if (this.hasBackButtonTarget) {
+      this.backButtonTarget.classList.toggle("invisible", step === 1)
+    }
+
+    // Next/continue button
+    if (this.hasNextButtonTarget) {
+      this.nextButtonTarget.disabled = (step === 1 && !this.selectedDateValue)
+    }
+  }
+
+  // === Form submission ===
+
+  skipAi(event) {
+    event.preventDefault()
+    this.populateHiddenFields()
+
+    const form = this.element.querySelector("form")
+    form.action = this.createUrlValue
+    form.requestSubmit()
+  }
+
+  beforeSubmit() {
+    this.populateHiddenFields()
+  }
+
+  populateHiddenFields() {
+    if (!this.selectedDateValue) return
+
+    const start = new Date(this.selectedDateValue + "T00:00:00")
+    const end = new Date(start)
+    end.setDate(end.getDate() + this.selectedDaysValue - 1)
+
+    const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+      "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+    const name = `Week of ${monthNames[start.getMonth()]} ${start.getDate()}, ${start.getFullYear()}`
+
+    this.nameFieldTarget.value = name
+    this.startDateFieldTarget.value = this.selectedDateValue
+    this.endDateFieldTarget.value = this.formatDate(end)
+  }
+
+  // === Helpers ===
+
+  formatDate(date) {
+    const y = date.getFullYear()
+    const m = String(date.getMonth() + 1).padStart(2, "0")
+    const d = String(date.getDate()).padStart(2, "0")
+    return `${y}-${m}-${d}`
+  }
+
+  formatDisplayDate(iso) {
+    const date = new Date(iso + "T00:00:00")
+    const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+      "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+    const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+    return `${dayNames[date.getDay()]}, ${monthNames[date.getMonth()]} ${date.getDate()}`
+  }
+}

--- a/app/views/accounts/meal_plans/_wizard.html.erb
+++ b/app/views/accounts/meal_plans/_wizard.html.erb
@@ -1,0 +1,173 @@
+<div data-controller="meal-plan-wizard ai-generate"
+     data-meal-plan-wizard-create-url-value="<%= meal_plans_path %>"
+     data-meal-plan-wizard-generate-url-value="<%= start_generate_meal_plans_path %>">
+
+  <%# === Progress Indicator === %>
+  <div class="flex items-center justify-center mb-8 px-4">
+    <% [ "Date", "Duration", "AI" ].each_with_index do |label, idx| %>
+      <div class="flex flex-col items-center" data-meal-plan-wizard-target="stepIndicator">
+        <div data-circle class="w-8 h-8 rounded-full flex items-center justify-center <%= idx == 0 ? 'bg-primary-600 text-white text-sm font-bold' : 'bg-warm-100 text-warm-400 text-sm font-medium' %>">
+          <%= idx + 1 %>
+        </div>
+        <span data-label class="text-xs font-medium <%= idx == 0 ? 'text-primary-700' : 'text-warm-400' %> mt-1"><%= label %></span>
+      </div>
+      <% unless idx == 2 %>
+        <div class="flex-1 mx-2 mt-[-1rem]">
+          <div data-line class="h-0.5 bg-warm-200"></div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+
+  <%# === Hidden Form === %>
+  <%= form_with(model: meal_plan, url: meal_plans_path, class: "hidden", id: dom_id(meal_plan, :form),
+        data: { ai_generate_target: "form", action: "submit->meal-plan-wizard#beforeSubmit" }) do |f| %>
+    <input type="hidden" name="meal_plan[name]" data-meal-plan-wizard-target="nameField">
+    <input type="hidden" name="meal_plan[start_date]" data-meal-plan-wizard-target="startDateField">
+    <input type="hidden" name="meal_plan[end_date]" data-meal-plan-wizard-target="endDateField">
+  <% end %>
+
+  <%# === Step 1: Calendar === %>
+  <div data-meal-plan-wizard-target="step" class="card-warm rounded-xl p-6">
+    <h2 class="text-2xl font-display font-bold text-warm-900 text-center mb-1">When does your plan start?</h2>
+    <p class="text-sm text-warm-500 text-center mb-6">Pick a date from the calendar</p>
+
+    <div class="max-w-sm mx-auto">
+      <%# Month navigation %>
+      <div class="flex items-center justify-between mb-4">
+        <button type="button"
+          data-action="meal-plan-wizard#prevMonthAction"
+          data-meal-plan-wizard-target="prevMonth"
+          class="w-8 h-8 rounded-full flex items-center justify-center hover:bg-warm-100 text-warm-500 transition-colors">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+        </button>
+        <h3 data-meal-plan-wizard-target="calendarTitle" class="text-lg font-display font-bold text-warm-800"></h3>
+        <button type="button"
+          data-action="meal-plan-wizard#nextMonthAction"
+          class="w-8 h-8 rounded-full flex items-center justify-center hover:bg-warm-100 text-warm-500 transition-colors">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+        </button>
+      </div>
+
+      <%# Day-of-week header %>
+      <div class="grid grid-cols-7 gap-1 mb-2">
+        <% %w[Su Mo Tu We Th Fr Sa].each do |dow| %>
+          <div class="text-center text-xs font-semibold text-warm-400 uppercase tracking-wider py-1"><%= dow %></div>
+        <% end %>
+      </div>
+
+      <%# Calendar grid (populated by JS) %>
+      <div data-meal-plan-wizard-target="calendarGrid" class="grid grid-cols-7 gap-1">
+      </div>
+    </div>
+  </div>
+
+  <%# === Step 2: Duration === %>
+  <div data-meal-plan-wizard-target="step" class="hidden card-warm rounded-xl p-6">
+    <h2 class="text-2xl font-display font-bold text-warm-900 text-center mb-1">How many days?</h2>
+    <p class="text-sm text-warm-500 text-center mb-6">Starting <span data-meal-plan-wizard-target="selectedDateText" class="font-semibold text-warm-700"></span></p>
+
+    <div class="max-w-sm mx-auto space-y-6">
+      <%# Duration buttons %>
+      <div class="grid grid-cols-5 gap-3">
+        <% [5, 6, 7, 8, 9].each do |n| %>
+          <button type="button"
+            data-action="meal-plan-wizard#selectDuration"
+            data-meal-plan-wizard-target="durationButton"
+            data-days="<%= n %>"
+            class="py-4 rounded-xl border-2 text-center font-display font-bold text-lg transition-all duration-150
+              <%= n == 7 ? 'border-primary-500 bg-primary-50 text-primary-700 ring-2 ring-primary-200 scale-105' : 'border-warm-200 bg-white text-warm-700 hover:border-warm-300' %>">
+            <%= n %>
+          </button>
+        <% end %>
+      </div>
+
+      <%# Custom days %>
+      <div class="text-center">
+        <button type="button"
+          data-action="meal-plan-wizard#showCustomDays"
+          data-meal-plan-wizard-target="customDaysLink"
+          class="text-sm text-primary-600 hover:text-primary-700 underline underline-offset-2">
+          Enter a custom number of days
+        </button>
+        <div data-meal-plan-wizard-target="customDaysInput" class="hidden mt-3 flex items-center justify-center gap-3">
+          <label class="text-sm text-warm-600">Days:</label>
+          <input type="number" min="1" max="30" value="7"
+            data-action="input->meal-plan-wizard#setCustomDays"
+            class="w-20 rounded-lg border-warm-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 text-center font-bold">
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <%# === Step 3: AI === %>
+  <div data-meal-plan-wizard-target="step" class="hidden card-warm rounded-xl p-6">
+    <h2 class="text-2xl font-display font-bold text-warm-900 text-center mb-1">Fill your plan with AI?</h2>
+    <p data-meal-plan-wizard-target="summaryText" class="text-sm text-warm-500 text-center mb-6"></p>
+
+    <div class="space-y-5">
+      <%# Preference chips %>
+      <div>
+        <label class="block text-sm font-medium text-warm-700 mb-2">Preferences</label>
+        <div class="flex flex-wrap gap-2" data-ai-generate-target="chips">
+          <% MealPlanGenerator::PREFERENCE_OPTIONS.each do |key, _| %>
+            <button type="button"
+              data-action="ai-generate#toggleChip"
+              data-preference-key="<%= key %>"
+              class="ai-preference-chip inline-flex items-center px-3 py-1.5 rounded-full text-sm font-medium border-2 transition-all
+                border-warm-300 bg-white text-warm-600 hover:border-primary-400 hover:text-primary-600">
+              <%= preference_chip_label(key) %>
+            </button>
+          <% end %>
+        </div>
+      </div>
+
+      <%# Special requests %>
+      <div>
+        <label for="ai_special_requests" class="block text-sm font-medium text-warm-700 mb-1">Special requests</label>
+        <textarea id="ai_special_requests" rows="2"
+          class="w-full rounded-lg border-warm-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 text-sm"
+          placeholder="e.g., Include chicken thigh recipes at least 3 times, avoid seafood on Monday..."
+          data-ai-generate-target="specialRequests"></textarea>
+      </div>
+
+      <%# Action buttons %>
+      <div class="flex flex-col sm:flex-row items-center justify-between gap-4 pt-4 border-t border-warm-200">
+        <button type="button"
+          data-action="meal-plan-wizard#skipAi"
+          class="text-sm text-warm-500 hover:text-warm-700 underline underline-offset-2 order-2 sm:order-1">
+          Skip &mdash; create empty plan
+        </button>
+
+        <button type="button"
+          data-action="ai-generate#submitWithAi"
+          class="inline-flex items-center gap-2 bg-primary-600 text-white px-6 py-2.5 rounded-xl hover:bg-primary-700 transition-colors font-semibold cursor-pointer shadow-md order-1 sm:order-2">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456z" />
+          </svg>
+          Generate with AI
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <%# === Navigation Footer (steps 1-2) === %>
+  <div data-meal-plan-wizard-target="navigationFooter" class="flex items-center justify-between mt-6">
+    <button type="button"
+      data-action="meal-plan-wizard#prevStep"
+      data-meal-plan-wizard-target="backButton"
+      class="invisible inline-flex items-center gap-1 text-sm font-medium text-warm-600 hover:text-warm-800 transition-colors">
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+      Back
+    </button>
+
+    <button type="button"
+      data-action="meal-plan-wizard#nextStep"
+      data-meal-plan-wizard-target="nextButton"
+      disabled
+      class="inline-flex items-center gap-1 bg-primary-600 text-white px-5 py-2 rounded-xl hover:bg-primary-700 transition-colors text-sm font-semibold cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed shadow-md">
+      Continue
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+    </button>
+  </div>
+</div>

--- a/app/views/accounts/meal_plans/new.html.erb
+++ b/app/views/accounts/meal_plans/new.html.erb
@@ -5,7 +5,5 @@
     <%= link_to "&larr; Back to Meal Plans".html_safe, meal_plans_path, class: "text-primary-600 hover:text-primary-700 text-sm font-medium" %>
   </div>
 
-  <h1 class="text-3xl font-display font-bold text-warm-900 mb-6">New Meal Plan</h1>
-
-  <%= render "form", meal_plan: @meal_plan %>
+  <%= render "wizard", meal_plan: @meal_plan %>
 </div>

--- a/test/controllers/accounts/meal_plans_controller_test.rb
+++ b/test/controllers/accounts/meal_plans_controller_test.rb
@@ -34,7 +34,7 @@ class Accounts::MealPlansControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(@session)
     get "#{account_path_prefix}/meal_plans/new"
     assert_response :success
-    assert_select "h1", "New Meal Plan"
+    assert_select "[data-controller*='meal-plan-wizard']"
   end
 
   test "should create meal plan and auto-generate days" do
@@ -281,12 +281,32 @@ class Accounts::MealPlansControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Generation failed: Not enough recipes", flash[:alert]
   end
 
-  test "new form includes AI generate toggle" do
+  test "new form includes AI generate controls" do
     sign_in_as(@session)
     get "#{account_path_prefix}/meal_plans/new"
     assert_response :success
     assert_select "[data-controller*='ai-generate']"
-    assert_select "[data-ai-generate-target='toggleButton']"
+  end
+
+  test "new form renders wizard with calendar" do
+    sign_in_as(@session)
+    get "#{account_path_prefix}/meal_plans/new"
+    assert_response :success
+    assert_select "[data-meal-plan-wizard-target='calendarGrid']"
+  end
+
+  test "new form renders duration buttons" do
+    sign_in_as(@session)
+    get "#{account_path_prefix}/meal_plans/new"
+    assert_response :success
+    assert_select "[data-meal-plan-wizard-target='durationButton']", 5
+  end
+
+  test "new form renders AI preferences in wizard" do
+    sign_in_as(@session)
+    get "#{account_path_prefix}/meal_plans/new"
+    assert_response :success
+    assert_select "[data-preference-key]", MealPlanGenerator::PREFERENCE_OPTIONS.size
   end
 
   # === Calendar view tests ===


### PR DESCRIPTION
## Summary
- Replace single-page meal plan creation form with an interactive 3-step wizard: date picker (inline calendar), duration selector (5-9 day buttons + custom), and AI generation step (preference chips + special requests)
- Plan name auto-generates as "Week of [date]"; participants removed from creation flow (add from show page)
- `_form.html.erb` unchanged — still used for the edit action

## Test plan
- [ ] Visit new meal plan page, verify 3-step wizard renders
- [ ] Calendar navigation: month arrows, past dates disabled, date selection auto-advances
- [ ] Duration buttons: 5-9 days, 7 highlighted by default, custom input works
- [ ] AI step: preference chips toggle, special requests textarea, Skip creates empty plan, Generate starts AI job
- [ ] Edit meal plan page still uses the original form partial
- [ ] `bin/rails test` — 896 tests pass
- [ ] `bin/rubocop` — 0 offenses
- [ ] `bin/brakeman` — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)