### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/app/javascript/controllers/collapsible_section_controller.js
+++ b/app/javascript/controllers/collapsible_section_controller.js
@@ -1,0 +1,35 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["content", "chevron"]
+  static values = { open: { type: Boolean, default: true } }
+
+  toggle() {
+    this.openValue = !this.openValue
+    this.updateVisibility()
+  }
+
+  updateVisibility() {
+    if (this.openValue) {
+      this.contentTarget.style.maxHeight = this.contentTarget.scrollHeight + "px"
+      this.contentTarget.style.opacity = "1"
+      if (this.hasChevronTarget) this.chevronTarget.style.transform = "rotate(0deg)"
+    } else {
+      this.contentTarget.style.maxHeight = "0px"
+      this.contentTarget.style.opacity = "0"
+      if (this.hasChevronTarget) this.chevronTarget.style.transform = "rotate(-90deg)"
+    }
+  }
+
+  contentTargetConnected() {
+    this.contentTarget.style.transition = "max-height 0.25s ease, opacity 0.2s ease"
+    this.contentTarget.style.overflow = "hidden"
+    if (this.openValue) {
+      this.contentTarget.style.maxHeight = "none"
+      this.contentTarget.style.opacity = "1"
+    } else {
+      this.contentTarget.style.maxHeight = "0px"
+      this.contentTarget.style.opacity = "0"
+    }
+  }
+}

--- a/app/views/accounts/dashboards/show.html.erb
+++ b/app/views/accounts/dashboards/show.html.erb
@@ -281,12 +281,12 @@
       <%# === WEEKLY OVERVIEW STRIP === %>
       <div class="mb-8 fade-up">
         <h2 class="text-lg font-display font-bold text-warm-900 mb-3">This Week</h2>
-        <div class="grid grid-cols-7 gap-2">
+        <div class="flex gap-2 overflow-x-auto pb-2 sm:grid sm:grid-cols-7 sm:overflow-visible sm:pb-0">
           <% @current_meal_plan.days.sort_by(&:date).each do |day| %>
             <% is_today = day.date == Date.current %>
             <% has_meals = day.meals.any? %>
             <%= link_to meal_plan_path(@current_meal_plan, anchor: "day-#{day.day_number}"),
-                  class: "block rounded-xl p-3 text-center transition-all #{
+                  class: "shrink-0 w-[72px] sm:w-auto block rounded-xl p-3 text-center transition-all #{
                     if is_today
                       'bg-primary-600 text-white shadow-md ring-2 ring-primary-300'
                     elsif has_meals

--- a/app/views/accounts/meal_plans/_day_card.html.erb
+++ b/app/views/accounts/meal_plans/_day_card.html.erb
@@ -26,8 +26,8 @@
                   <span class="text-sm text-warm-400"><%= meal.calories %> cal</span>
                 <% end %>
               </div>
-              <%= button_to meal_plan_meal_path(meal_plan, meal), method: :delete, class: "text-red-400 hover:text-red-600", data: { turbo_confirm: "Remove this meal?" } do %>
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <%= button_to meal_plan_meal_path(meal_plan, meal), method: :delete, class: "text-red-400 hover:text-red-600 min-w-[44px] min-h-[44px] flex items-center justify-center -mr-2", data: { turbo_confirm: "Remove this meal?" } do %>
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
                 </svg>
               <% end %>

--- a/app/views/accounts/meal_plans/show.html.erb
+++ b/app/views/accounts/meal_plans/show.html.erb
@@ -140,7 +140,7 @@
     <div class="lg:hidden" data-controller="calendar-swipe" data-calendar-swipe-current-index-value="0">
       <div class="flex gap-1 mb-4 overflow-x-auto pb-2 -mx-1 px-1">
         <% current_week.each_with_index do |day, i| %>
-          <button type="button" data-action="calendar-swipe#selectDay" data-day-index="<%= i %>" data-calendar-swipe-target="dayTab" class="shrink-0 px-3 py-2 rounded-lg text-sm font-medium transition-colors <%= i == 0 ? 'bg-primary-600 text-white' : 'bg-warm-100 text-warm-600' %>">
+          <button type="button" data-action="calendar-swipe#selectDay" data-day-index="<%= i %>" data-calendar-swipe-target="dayTab" class="shrink-0 px-4 py-3 min-w-[44px] min-h-[44px] rounded-lg text-sm font-medium transition-colors <%= i == 0 ? 'bg-primary-600 text-white' : 'bg-warm-100 text-warm-600' %>">
             <span class="block text-[10px] uppercase"><%= day.date.strftime("%a") %></span>
             <span class="block text-base font-bold"><%= day.date.day %></span>
           </button>
@@ -174,8 +174,8 @@
                             <% if meal.recipe.nutrition_data %><span><%= meal.calories %> cal</span><% end %>
                           </div>
                         </div>
-                        <%= button_to meal_plan_meal_path(@meal_plan, meal), method: :delete, class: "text-red-400 hover:text-red-600 shrink-0", data: { turbo_confirm: "Remove this meal?" } do %>
-                          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+                        <%= button_to meal_plan_meal_path(@meal_plan, meal), method: :delete, class: "text-red-400 hover:text-red-600 shrink-0 min-w-[44px] min-h-[44px] flex items-center justify-center", data: { turbo_confirm: "Remove this meal?" } do %>
+                          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
                         <% end %>
                       </div>
                     <% end %>

--- a/app/views/accounts/recipes/_form.html.erb
+++ b/app/views/accounts/recipes/_form.html.erb
@@ -74,7 +74,7 @@
             <% @recipe.images.each do |img| %>
               <div class="relative group">
                 <%= image_tag img.variant(:thumbnail), class: "w-20 h-20 rounded-lg object-cover shadow-sm", alt: "Recipe photo" %>
-                <%= button_to recipe_path(@recipe, purge_image_id: img.id), method: :patch, class: "absolute -top-1.5 -right-1.5 w-5 h-5 bg-red-500 text-white rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity shadow-sm hover:bg-red-600", data: { turbo_confirm: "Remove this photo?" } do %>
+                <%= button_to recipe_path(@recipe, purge_image_id: img.id), method: :patch, class: "absolute -top-1.5 -right-1.5 w-6 h-6 bg-red-500 text-white rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity shadow-sm hover:bg-red-600", data: { turbo_confirm: "Remove this photo?" } do %>
                   <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
                 <% end %>
               </div>
@@ -93,158 +93,181 @@
     </div>
   </div>
 
-  <div class="bg-white rounded-lg shadow p-6">
-    <h2 class="text-lg font-semibold text-warm-900 mb-4">Tags</h2>
-    <div>
-      <%= f.label :tag_list, "Tags", class: "block text-sm font-medium text-warm-700 mb-1" %>
-      <%= f.text_field :tag_list, value: @recipe.tag_list, class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500", placeholder: "e.g. quick, salad, tex-mex" %>
-      <p class="mt-1 text-sm text-warm-500">Separate tags with commas</p>
-    </div>
-  </div>
-
-  <%# ── Ingredients ── %>
-  <div class="bg-white rounded-lg shadow p-6" data-controller="nested-form">
-    <h2 class="text-lg font-semibold text-warm-900 mb-4">Ingredients</h2>
-
-    <div data-nested-form-target="target">
-      <%= f.fields_for :ingredients do |ingredient_form| %>
-        <div class="nested-form-wrapper flex gap-3 mb-3 items-center">
-          <%= ingredient_form.text_field :quantity, placeholder: "Qty", class: "w-20 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
-          <%= ingredient_form.select :unit, grouped_options_for_select(@unit_options, ingredient_form.object.unit), { include_blank: "Unit" }, class: "w-28 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
-          <%= ingredient_form.text_field :name, placeholder: "Ingredient name", class: "flex-1 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
-          <%= ingredient_form.hidden_field :_destroy, value: "0" %>
-          <%= ingredient_form.hidden_field :id %>
-          <button type="button" data-action="nested-form#remove" class="text-red-500 hover:text-red-700 text-sm font-medium">Remove</button>
-        </div>
-      <% end %>
-    </div>
-
-    <template data-nested-form-target="template">
-      <div class="nested-form-wrapper flex gap-3 mb-3 items-center" data-new-record="true">
-        <input type="text" name="recipe[ingredients_attributes][NEW_RECORD][quantity]" placeholder="Qty" class="w-20 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" />
-        <select name="recipe[ingredients_attributes][NEW_RECORD][unit]" class="w-28 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm">
-          <option value="">Unit</option>
-          <%= grouped_options_for_select(@unit_options) %>
-        </select>
-        <input type="text" name="recipe[ingredients_attributes][NEW_RECORD][name]" placeholder="Ingredient name" class="flex-1 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" />
-        <input type="hidden" name="recipe[ingredients_attributes][NEW_RECORD][_destroy]" value="0" />
-        <button type="button" data-action="nested-form#remove" class="text-red-500 hover:text-red-700 text-sm font-medium">Remove</button>
+  <%# ── Tags (collapsible) ── %>
+  <div class="bg-white rounded-lg shadow" data-controller="collapsible-section">
+    <button type="button" data-action="collapsible-section#toggle" class="w-full flex items-center justify-between p-6 min-h-[44px]">
+      <h2 class="text-lg font-semibold text-warm-900">Tags</h2>
+      <svg data-collapsible-section-target="chevron" class="w-5 h-5 text-warm-400 transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+    </button>
+    <div data-collapsible-section-target="content" class="px-6 pb-6">
+      <div>
+        <%= f.label :tag_list, "Tags", class: "block text-sm font-medium text-warm-700 mb-1" %>
+        <%= f.text_field :tag_list, value: @recipe.tag_list, class: "w-full px-4 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500", placeholder: "e.g. quick, salad, tex-mex" %>
+        <p class="mt-1 text-sm text-warm-500">Separate tags with commas</p>
       </div>
-    </template>
-
-    <button type="button" data-action="nested-form#add" class="mt-2 text-primary-600 hover:text-primary-800 text-sm font-medium">+ Add Ingredient</button>
+    </div>
   </div>
 
-  <%# ── Instructions ── %>
-  <div class="bg-white rounded-lg shadow p-6" data-controller="nested-form step-numbering">
-    <h2 class="text-lg font-semibold text-warm-900 mb-4">Instructions</h2>
-
-    <div data-nested-form-target="target">
-      <%= f.fields_for :instructions do |instruction_form| %>
-        <div class="nested-form-wrapper flex gap-3 mb-3 items-start">
-          <%= instruction_form.number_field :step_number, placeholder: "#", min: 1, readonly: true, class: "w-16 px-3 py-2 border border-warm-300 rounded-lg bg-warm-50 text-sm" %>
-          <%= instruction_form.text_area :instruction, placeholder: "Describe this step...", rows: 2, class: "flex-1 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
-          <%= instruction_form.hidden_field :_destroy, value: "0" %>
-          <%= instruction_form.hidden_field :id %>
-          <button type="button" data-action="nested-form#remove step-numbering#renumber" class="text-red-500 hover:text-red-700 text-sm font-medium mt-2">Remove</button>
-        </div>
-      <% end %>
-    </div>
-
-    <template data-nested-form-target="template">
-      <div class="nested-form-wrapper flex gap-3 mb-3 items-start" data-new-record="true">
-        <input type="number" name="recipe[instructions_attributes][NEW_RECORD][step_number]" placeholder="#" min="1" readonly class="w-16 px-3 py-2 border border-warm-300 rounded-lg bg-warm-50 text-sm" />
-        <textarea name="recipe[instructions_attributes][NEW_RECORD][instruction]" placeholder="Describe this step..." rows="2" class="flex-1 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm"></textarea>
-        <input type="hidden" name="recipe[instructions_attributes][NEW_RECORD][_destroy]" value="0" />
-        <button type="button" data-action="nested-form#remove step-numbering#renumber" class="text-red-500 hover:text-red-700 text-sm font-medium mt-2">Remove</button>
+  <%# ── Ingredients (collapsible) ── %>
+  <div class="bg-white rounded-lg shadow" data-controller="collapsible-section nested-form">
+    <button type="button" data-action="collapsible-section#toggle" class="w-full flex items-center justify-between p-6 min-h-[44px]">
+      <h2 class="text-lg font-semibold text-warm-900">Ingredients</h2>
+      <svg data-collapsible-section-target="chevron" class="w-5 h-5 text-warm-400 transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+    </button>
+    <div data-collapsible-section-target="content" class="px-6 pb-6">
+      <div data-nested-form-target="target">
+        <%= f.fields_for :ingredients do |ingredient_form| %>
+          <div class="nested-form-wrapper flex flex-wrap sm:flex-nowrap gap-2 sm:gap-3 mb-3 items-center">
+            <%= ingredient_form.text_field :quantity, placeholder: "Qty", class: "w-16 sm:w-20 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
+            <%= ingredient_form.select :unit, grouped_options_for_select(@unit_options, ingredient_form.object.unit), { include_blank: "Unit" }, class: "w-24 sm:w-28 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
+            <%= ingredient_form.text_field :name, placeholder: "Ingredient name", class: "flex-1 min-w-0 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
+            <%= ingredient_form.hidden_field :_destroy, value: "0" %>
+            <%= ingredient_form.hidden_field :id %>
+            <button type="button" data-action="nested-form#remove" class="text-red-500 hover:text-red-700 text-sm font-medium min-w-[44px] min-h-[44px] flex items-center justify-center shrink-0">Remove</button>
+          </div>
+        <% end %>
       </div>
-    </template>
 
-    <button type="button" data-action="nested-form#add step-numbering#renumber" class="mt-2 text-primary-600 hover:text-primary-800 text-sm font-medium">+ Add Step</button>
+      <template data-nested-form-target="template">
+        <div class="nested-form-wrapper flex flex-wrap sm:flex-nowrap gap-2 sm:gap-3 mb-3 items-center" data-new-record="true">
+          <input type="text" name="recipe[ingredients_attributes][NEW_RECORD][quantity]" placeholder="Qty" class="w-16 sm:w-20 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" />
+          <select name="recipe[ingredients_attributes][NEW_RECORD][unit]" class="w-24 sm:w-28 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm">
+            <option value="">Unit</option>
+            <%= grouped_options_for_select(@unit_options) %>
+          </select>
+          <input type="text" name="recipe[ingredients_attributes][NEW_RECORD][name]" placeholder="Ingredient name" class="flex-1 min-w-0 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" />
+          <input type="hidden" name="recipe[ingredients_attributes][NEW_RECORD][_destroy]" value="0" />
+          <button type="button" data-action="nested-form#remove" class="text-red-500 hover:text-red-700 text-sm font-medium min-w-[44px] min-h-[44px] flex items-center justify-center shrink-0">Remove</button>
+        </div>
+      </template>
+
+      <button type="button" data-action="nested-form#add" class="mt-2 text-primary-600 hover:text-primary-800 text-sm font-medium min-h-[44px]">+ Add Ingredient</button>
+    </div>
   </div>
 
-  <%# ── Tips ── %>
-  <div class="bg-white rounded-lg shadow p-6" data-controller="nested-form">
-    <h2 class="text-lg font-semibold text-warm-900 mb-4">Tips</h2>
-
-    <div data-nested-form-target="target">
-      <%= f.fields_for :tips do |tip_form| %>
-        <div class="nested-form-wrapper flex gap-3 mb-3 items-start">
-          <%= tip_form.text_area :tip, placeholder: "Add a helpful tip...", rows: 2, class: "flex-1 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
-          <%= tip_form.hidden_field :_destroy, value: "0" %>
-          <%= tip_form.hidden_field :id %>
-          <button type="button" data-action="nested-form#remove" class="text-red-500 hover:text-red-700 text-sm font-medium mt-2">Remove</button>
-        </div>
-      <% end %>
-    </div>
-
-    <template data-nested-form-target="template">
-      <div class="nested-form-wrapper flex gap-3 mb-3 items-start" data-new-record="true">
-        <textarea name="recipe[tips_attributes][NEW_RECORD][tip]" placeholder="Add a helpful tip..." rows="2" class="flex-1 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm"></textarea>
-        <input type="hidden" name="recipe[tips_attributes][NEW_RECORD][_destroy]" value="0" />
-        <button type="button" data-action="nested-form#remove" class="text-red-500 hover:text-red-700 text-sm font-medium mt-2">Remove</button>
+  <%# ── Instructions (collapsible) ── %>
+  <div class="bg-white rounded-lg shadow" data-controller="collapsible-section nested-form step-numbering">
+    <button type="button" data-action="collapsible-section#toggle" class="w-full flex items-center justify-between p-6 min-h-[44px]">
+      <h2 class="text-lg font-semibold text-warm-900">Instructions</h2>
+      <svg data-collapsible-section-target="chevron" class="w-5 h-5 text-warm-400 transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+    </button>
+    <div data-collapsible-section-target="content" class="px-6 pb-6">
+      <div data-nested-form-target="target">
+        <%= f.fields_for :instructions do |instruction_form| %>
+          <div class="nested-form-wrapper flex gap-2 sm:gap-3 mb-3 items-start">
+            <%= instruction_form.number_field :step_number, placeholder: "#", min: 1, readonly: true, class: "w-12 sm:w-16 px-2 sm:px-3 py-2 border border-warm-300 rounded-lg bg-warm-50 text-sm" %>
+            <%= instruction_form.text_area :instruction, placeholder: "Describe this step...", rows: 2, class: "flex-1 min-w-0 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
+            <%= instruction_form.hidden_field :_destroy, value: "0" %>
+            <%= instruction_form.hidden_field :id %>
+            <button type="button" data-action="nested-form#remove step-numbering#renumber" class="text-red-500 hover:text-red-700 text-sm font-medium mt-2 min-w-[44px] min-h-[44px] flex items-center justify-center shrink-0">Remove</button>
+          </div>
+        <% end %>
       </div>
-    </template>
 
-    <button type="button" data-action="nested-form#add" class="mt-2 text-primary-600 hover:text-primary-800 text-sm font-medium">+ Add Tip</button>
+      <template data-nested-form-target="template">
+        <div class="nested-form-wrapper flex gap-2 sm:gap-3 mb-3 items-start" data-new-record="true">
+          <input type="number" name="recipe[instructions_attributes][NEW_RECORD][step_number]" placeholder="#" min="1" readonly class="w-12 sm:w-16 px-2 sm:px-3 py-2 border border-warm-300 rounded-lg bg-warm-50 text-sm" />
+          <textarea name="recipe[instructions_attributes][NEW_RECORD][instruction]" placeholder="Describe this step..." rows="2" class="flex-1 min-w-0 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm"></textarea>
+          <input type="hidden" name="recipe[instructions_attributes][NEW_RECORD][_destroy]" value="0" />
+          <button type="button" data-action="nested-form#remove step-numbering#renumber" class="text-red-500 hover:text-red-700 text-sm font-medium mt-2 min-w-[44px] min-h-[44px] flex items-center justify-center shrink-0">Remove</button>
+        </div>
+      </template>
+
+      <button type="button" data-action="nested-form#add step-numbering#renumber" class="mt-2 text-primary-600 hover:text-primary-800 text-sm font-medium min-h-[44px]">+ Add Step</button>
+    </div>
   </div>
 
-  <div class="bg-white rounded-lg shadow p-6" data-controller="nutrition-toggle">
-    <h2 class="text-lg font-semibold text-warm-900 mb-4">Nutrition (per serving)</h2>
-
-    <div class="mb-4">
-      <%= f.label :nutrition_mode, "Nutrition mode", class: "block text-sm font-medium text-warm-700 mb-1" %>
-      <% default_mode = @recipe.nutrition_data&.auto_calculated? ? "auto" : (@recipe.persisted? ? "manual" : "auto") %>
-      <%= f.select :nutrition_mode, [["Auto-calculate from ingredients", "auto"], ["Enter manually", "manual"]], { selected: default_mode }, class: "w-full px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm", data: { nutrition_toggle_target: "mode", action: "nutrition-toggle#toggle" } %>
-    </div>
-
-    <div data-nutrition-toggle-target="autoMessage" class="hidden">
-      <p class="text-sm text-warm-600">Nutrition will be calculated automatically from ingredients when you save.</p>
-      <% if @recipe.nutrition_data&.auto_calculated? && @recipe.nutrition_data&.calories.present? %>
-        <div class="mt-3 bg-primary-50 border border-primary-200 rounded-lg p-3">
-          <p class="text-sm font-medium text-primary-800 mb-2">Current calculated values:</p>
-          <div class="grid grid-cols-3 gap-2 text-sm text-primary-700">
-            <span>Calories: <%= @recipe.nutrition_data.calories %></span>
-            <span>Fat: <%= @recipe.nutrition_data.fat %>g</span>
-            <span>Protein: <%= @recipe.nutrition_data.protein %>g</span>
-            <span>Carbs: <%= @recipe.nutrition_data.carbs %>g</span>
-            <span>Fiber: <%= @recipe.nutrition_data.fiber %>g</span>
-            <span>Sodium: <%= @recipe.nutrition_data.sodium %>mg</span>
+  <%# ── Tips (collapsible) ── %>
+  <div class="bg-white rounded-lg shadow" data-controller="collapsible-section nested-form">
+    <button type="button" data-action="collapsible-section#toggle" class="w-full flex items-center justify-between p-6 min-h-[44px]">
+      <h2 class="text-lg font-semibold text-warm-900">Tips</h2>
+      <svg data-collapsible-section-target="chevron" class="w-5 h-5 text-warm-400 transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+    </button>
+    <div data-collapsible-section-target="content" class="px-6 pb-6">
+      <div data-nested-form-target="target">
+        <%= f.fields_for :tips do |tip_form| %>
+          <div class="nested-form-wrapper flex gap-2 sm:gap-3 mb-3 items-start">
+            <%= tip_form.text_area :tip, placeholder: "Add a helpful tip...", rows: 2, class: "flex-1 min-w-0 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
+            <%= tip_form.hidden_field :_destroy, value: "0" %>
+            <%= tip_form.hidden_field :id %>
+            <button type="button" data-action="nested-form#remove" class="text-red-500 hover:text-red-700 text-sm font-medium mt-2 min-w-[44px] min-h-[44px] flex items-center justify-center shrink-0">Remove</button>
           </div>
+        <% end %>
+      </div>
+
+      <template data-nested-form-target="template">
+        <div class="nested-form-wrapper flex gap-2 sm:gap-3 mb-3 items-start" data-new-record="true">
+          <textarea name="recipe[tips_attributes][NEW_RECORD][tip]" placeholder="Add a helpful tip..." rows="2" class="flex-1 min-w-0 px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm"></textarea>
+          <input type="hidden" name="recipe[tips_attributes][NEW_RECORD][_destroy]" value="0" />
+          <button type="button" data-action="nested-form#remove" class="text-red-500 hover:text-red-700 text-sm font-medium mt-2 min-w-[44px] min-h-[44px] flex items-center justify-center shrink-0">Remove</button>
         </div>
-      <% end %>
-    </div>
+      </template>
 
-    <div data-nutrition-toggle-target="manualFields">
-      <%= f.fields_for :nutrition_data do |nutrition_form| %>
-        <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
-          <div>
-            <%= nutrition_form.label :calories, class: "block text-sm font-medium text-warm-700 mb-1" %>
-            <%= nutrition_form.number_field :calories, min: 0, class: "w-full px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
+      <button type="button" data-action="nested-form#add" class="mt-2 text-primary-600 hover:text-primary-800 text-sm font-medium min-h-[44px]">+ Add Tip</button>
+    </div>
+  </div>
+
+  <%# ── Nutrition (collapsible) ── %>
+  <div class="bg-white rounded-lg shadow" data-controller="collapsible-section nutrition-toggle">
+    <button type="button" data-action="collapsible-section#toggle" class="w-full flex items-center justify-between p-6 min-h-[44px]">
+      <h2 class="text-lg font-semibold text-warm-900">Nutrition (per serving)</h2>
+      <svg data-collapsible-section-target="chevron" class="w-5 h-5 text-warm-400 transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+    </button>
+    <div data-collapsible-section-target="content" class="px-6 pb-6">
+      <div class="mb-4">
+        <%= f.label :nutrition_mode, "Nutrition mode", class: "block text-sm font-medium text-warm-700 mb-1" %>
+        <% default_mode = @recipe.nutrition_data&.auto_calculated? ? "auto" : (@recipe.persisted? ? "manual" : "auto") %>
+        <%= f.select :nutrition_mode, [["Auto-calculate from ingredients", "auto"], ["Enter manually", "manual"]], { selected: default_mode }, class: "w-full px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm", data: { nutrition_toggle_target: "mode", action: "nutrition-toggle#toggle" } %>
+      </div>
+
+      <div data-nutrition-toggle-target="autoMessage" class="hidden">
+        <p class="text-sm text-warm-600">Nutrition will be calculated automatically from ingredients when you save.</p>
+        <% if @recipe.nutrition_data&.auto_calculated? && @recipe.nutrition_data&.calories.present? %>
+          <div class="mt-3 bg-primary-50 border border-primary-200 rounded-lg p-3">
+            <p class="text-sm font-medium text-primary-800 mb-2">Current calculated values:</p>
+            <div class="grid grid-cols-2 sm:grid-cols-3 gap-2 text-sm text-primary-700">
+              <span>Calories: <%= @recipe.nutrition_data.calories %></span>
+              <span>Fat: <%= @recipe.nutrition_data.fat %>g</span>
+              <span>Protein: <%= @recipe.nutrition_data.protein %>g</span>
+              <span>Carbs: <%= @recipe.nutrition_data.carbs %>g</span>
+              <span>Fiber: <%= @recipe.nutrition_data.fiber %>g</span>
+              <span>Sodium: <%= @recipe.nutrition_data.sodium %>mg</span>
+            </div>
           </div>
-          <div>
-            <%= nutrition_form.label :fat, "Fat (g)", class: "block text-sm font-medium text-warm-700 mb-1" %>
-            <%= nutrition_form.number_field :fat, min: 0, step: 0.1, class: "w-full px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
+        <% end %>
+      </div>
+
+      <div data-nutrition-toggle-target="manualFields">
+        <%= f.fields_for :nutrition_data do |nutrition_form| %>
+          <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
+            <div>
+              <%= nutrition_form.label :calories, class: "block text-sm font-medium text-warm-700 mb-1" %>
+              <%= nutrition_form.number_field :calories, min: 0, class: "w-full px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
+            </div>
+            <div>
+              <%= nutrition_form.label :fat, "Fat (g)", class: "block text-sm font-medium text-warm-700 mb-1" %>
+              <%= nutrition_form.number_field :fat, min: 0, step: 0.1, class: "w-full px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
+            </div>
+            <div>
+              <%= nutrition_form.label :protein, "Protein (g)", class: "block text-sm font-medium text-warm-700 mb-1" %>
+              <%= nutrition_form.number_field :protein, min: 0, step: 0.1, class: "w-full px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
+            </div>
+            <div>
+              <%= nutrition_form.label :carbs, "Carbs (g)", class: "block text-sm font-medium text-warm-700 mb-1" %>
+              <%= nutrition_form.number_field :carbs, min: 0, step: 0.1, class: "w-full px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
+            </div>
+            <div>
+              <%= nutrition_form.label :fiber, "Fiber (g)", class: "block text-sm font-medium text-warm-700 mb-1" %>
+              <%= nutrition_form.number_field :fiber, min: 0, step: 0.1, class: "w-full px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
+            </div>
+            <div>
+              <%= nutrition_form.label :sodium, "Sodium (mg)", class: "block text-sm font-medium text-warm-700 mb-1" %>
+              <%= nutrition_form.number_field :sodium, min: 0, class: "w-full px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
+            </div>
           </div>
-          <div>
-            <%= nutrition_form.label :protein, "Protein (g)", class: "block text-sm font-medium text-warm-700 mb-1" %>
-            <%= nutrition_form.number_field :protein, min: 0, step: 0.1, class: "w-full px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
-          </div>
-          <div>
-            <%= nutrition_form.label :carbs, "Carbs (g)", class: "block text-sm font-medium text-warm-700 mb-1" %>
-            <%= nutrition_form.number_field :carbs, min: 0, step: 0.1, class: "w-full px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
-          </div>
-          <div>
-            <%= nutrition_form.label :fiber, "Fiber (g)", class: "block text-sm font-medium text-warm-700 mb-1" %>
-            <%= nutrition_form.number_field :fiber, min: 0, step: 0.1, class: "w-full px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
-          </div>
-          <div>
-            <%= nutrition_form.label :sodium, "Sodium (mg)", class: "block text-sm font-medium text-warm-700 mb-1" %>
-            <%= nutrition_form.number_field :sodium, min: 0, class: "w-full px-3 py-2 border border-warm-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 text-sm" %>
-          </div>
-        </div>
-        <%= nutrition_form.hidden_field :id %>
-      <% end %>
+          <%= nutrition_form.hidden_field :id %>
+        <% end %>
+      </div>
     </div>
   </div>
 

--- a/app/views/identity/access_tokens/index.html.erb
+++ b/app/views/identity/access_tokens/index.html.erb
@@ -14,7 +14,8 @@
 <% end %>
 
 <% if @access_tokens.any? %>
-  <div class="bg-white shadow rounded-lg overflow-hidden">
+  <%# Desktop table %>
+  <div class="hidden sm:block bg-white shadow rounded-lg overflow-hidden">
     <table class="min-w-full divide-y divide-warm-200">
       <thead class="bg-warm-50">
         <tr>
@@ -57,6 +58,32 @@
       </tbody>
     </table>
   </div>
+
+  <%# Mobile card layout %>
+  <div class="sm:hidden space-y-3">
+    <% @access_tokens.each do |token| %>
+      <div class="bg-white shadow rounded-lg p-4">
+        <div class="flex items-start justify-between gap-3">
+          <div class="flex-1 min-w-0">
+            <p class="text-sm font-medium text-warm-900"><%= token.name || "Unnamed token" %></p>
+            <div class="flex flex-wrap items-center gap-2 mt-2">
+              <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium <%= token.write? ? 'bg-orange-100 text-orange-800' : 'bg-accent-100 text-accent-800' %>">
+                <%= token.permission %>
+              </span>
+              <span class="text-xs text-warm-500">
+                Expires: <% if token.expires_at %><%= token.expires_at.strftime("%b %d, %Y") %><% else %>Never<% end %>
+              </span>
+            </div>
+            <p class="text-xs text-warm-400 mt-1">Created <%= token.created_at.strftime("%b %d, %Y") %></p>
+          </div>
+          <%= button_to "Revoke", identity_access_token_path(token),
+              method: :delete,
+              class: "text-red-600 hover:text-red-900 text-sm font-medium min-w-[44px] min-h-[44px] flex items-center justify-center shrink-0",
+              data: { turbo_confirm: "Are you sure you want to revoke this token?" } %>
+        </div>
+      </div>
+    <% end %>
+  </div>
 <% else %>
   <div class="text-center py-12 bg-warm-50 rounded-lg">
     <p class="text-warm-500 mb-4">No access tokens yet</p>
@@ -66,19 +93,19 @@
 
 <div class="mt-10">
   <h3 class="text-xl font-display font-bold text-warm-900 mb-4">Claude Desktop Integration</h3>
-  <div class="bg-white shadow rounded-lg p-6">
+  <div class="bg-white shadow rounded-lg p-4 sm:p-6">
     <p class="text-sm text-warm-600 mb-4">
       Connect MealSzn to Claude Desktop to manage your recipes, meal plans, and shopping lists through conversation.
       Create a <strong>write</strong> permission token above, then add this to your Claude Desktop config:
     </p>
 
     <p class="text-xs text-warm-500 mb-2">
-      <strong>macOS:</strong> <code class="bg-warm-100 px-1 rounded">~/Library/Application Support/Claude/claude_desktop_config.json</code><br>
-      <strong>Windows:</strong> <code class="bg-warm-100 px-1 rounded">%APPDATA%\Claude\claude_desktop_config.json</code>
+      <strong>macOS:</strong> <code class="bg-warm-100 px-1 rounded text-xs break-all">~/Library/Application Support/Claude/claude_desktop_config.json</code><br>
+      <strong>Windows:</strong> <code class="bg-warm-100 px-1 rounded text-xs break-all">%APPDATA%\Claude\claude_desktop_config.json</code>
     </p>
 
     <div class="relative">
-      <pre class="p-4 bg-warm-900 text-warm-100 rounded-lg text-sm font-mono overflow-x-auto"><code>{
+      <pre class="p-3 sm:p-4 bg-warm-900 text-warm-100 rounded-lg text-xs sm:text-sm font-mono overflow-x-auto"><code>{
   "mcpServers": {
     "meal-szn": {
       "url": "<%= request.base_url %>/mcp/sse",

--- a/app/views/identity/sessions/index.html.erb
+++ b/app/views/identity/sessions/index.html.erb
@@ -2,7 +2,8 @@
 
 <h2 class="text-2xl font-display font-bold text-warm-900 mb-6">Active Sessions</h2>
 
-<div class="bg-white shadow rounded-lg overflow-hidden">
+<%# Desktop table %>
+<div class="hidden sm:block bg-white shadow rounded-lg overflow-hidden">
   <table class="min-w-full divide-y divide-warm-200">
     <thead class="bg-warm-50">
       <tr>
@@ -45,4 +46,36 @@
       <% end %>
     </tbody>
   </table>
+</div>
+
+<%# Mobile card layout %>
+<div class="sm:hidden space-y-3">
+  <% @sessions.each do |session| %>
+    <div class="bg-white shadow rounded-lg p-4 <%= session == @current_session ? 'ring-2 ring-primary-200 bg-primary-50' : '' %>">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center gap-2 mb-1">
+            <% if session == @current_session %>
+              <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-primary-100 text-primary-800 shrink-0">
+                Current
+              </span>
+            <% end %>
+          </div>
+          <p class="text-sm text-warm-900 truncate" title="<%= session.user_agent %>">
+            <%= session.user_agent.to_s.truncate(40) || "Unknown device" %>
+          </p>
+          <div class="flex flex-wrap gap-x-4 gap-y-1 mt-2 text-xs text-warm-500">
+            <span>IP: <%= session.ip_address || "Unknown" %></span>
+            <span><%= time_ago_in_words(session.updated_at) %> ago</span>
+          </div>
+        </div>
+        <% unless session == @current_session %>
+          <%= button_to "Terminate", identity_session_path(session),
+              method: :delete,
+              class: "text-red-600 hover:text-red-900 text-sm font-medium min-w-[44px] min-h-[44px] flex items-center justify-center shrink-0",
+              data: { turbo_confirm: "Are you sure you want to terminate this session?" } %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
 </div>


### PR DESCRIPTION
## Summary

Addresses remaining items 2-4 from #26: touch targets, collapsible recipe form, and horizontal scroll fixes at 375px viewport width.

## Changes

- **Touch targets (min 44px):** Enlarged meal delete buttons, calendar day tabs, and recipe form Remove buttons with min-w/min-h constraints
- **Collapsible recipe form:** New collapsible_section_controller.js Stimulus controller; Tags, Ingredients, Instructions, Tips, and Nutrition sections are collapsible (all expanded by default)
- **Horizontal scroll fixes:** Identity sessions/access tokens tables use card layout on mobile (sm:hidden / hidden sm:block); dashboard This Week strip is horizontally scrollable on mobile instead of forced 7-column grid
- **Ingredient rows:** Use flex-wrap on mobile so Qty/Unit/Name fields wrap instead of overflowing

## Documentation

- README.md: No changes needed
- CLAUDE.md: No changes needed

## Testing

- Visit recipe new/edit form on narrow viewport - sections should be collapsible
- Check identity sessions and access tokens pages at 375px width - no horizontal scroll
- Check dashboard This Week strip at 375px - horizontally scrollable
- Verify meal delete buttons and calendar tabs have adequate touch targets
- All 923 tests pass, Rubocop clean, Brakeman 0 warnings
- Created #79 for bottom navigation bar (separate work item)

Closes #26