### PR TITLE
Add WebSocket streaming for AI operations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,10 +153,12 @@ Integrated via `fast-mcp` gem. Mounted at `/mcp` with HTTP/SSE transport. Allows
 - `status` enum: `pending`, `processing`, `completed`, `failed` (with validated transitions)
 - `result` JSON column for AI output, `error_message` for failures
 - `progress_percentage` (0–100) for incremental updates
-- Turbo Stream broadcasts on status changes to `[account, :ai_task_statuses]` stream
+- Turbo Stream broadcasts on status AND progress changes to `[account, :ai_task_statuses]` stream
 - Account-scoped with string UUID PK
 
 **Subclassing pattern:** Implement `#execute(**args)` returning a Hash. Call `update_progress(n)` for incremental updates. Error handling and status transitions are automatic.
+
+**Real-time progress UI:** Progress pages use `turbo_stream_from` to subscribe to broadcasts from `AiTaskStatus`. The `ai_progress_controller.js` Stimulus controller watches for status changes in the broadcast partial and redirects on completion/failure. Falls back to polling (via `fetch` every 2s) if WebSocket is unavailable. Reusable `shared/_ai_progress.html.erb` partial accepts `task`, `title`, `subtitle`, `completed_url`, `failed_url`, `poll_url`, and optional `milestones` hash.
 
 ### Recipe Import Pipeline
 

--- a/app/controllers/accounts/recipes_controller.rb
+++ b/app/controllers/accounts/recipes_controller.rb
@@ -191,11 +191,12 @@ class Accounts::RecipesController < ApplicationController
 
   def import_status
     @task = Current.account.ai_task_statuses.find(params[:task_id])
+    @failed_url = failure_path_for(@task)
 
     if @task.completed?
       redirect_to import_review_recipes_path(task_id: @task.id)
     elsif @task.failed?
-      redirect_to failure_path_for(@task), alert: "Import failed: #{@task.error_message}"
+      redirect_to @failed_url, alert: "Import failed: #{@task.error_message}"
     end
   end
 

--- a/app/javascript/controllers/ai_progress_controller.js
+++ b/app/javascript/controllers/ai_progress_controller.js
@@ -1,0 +1,112 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Watches for Turbo Stream broadcasts on the ai_task_status partial.
+// When the status changes to completed/failed, redirects the user.
+// Falls back to polling if the WebSocket connection is not established.
+export default class extends Controller {
+  static targets = ["statusFrame"]
+  static values = {
+    pollUrl: String,
+    completedUrl: String,
+    failedUrl: String,
+    pollInterval: { type: Number, default: 2000 }
+  }
+
+  connect() {
+    this.pollTimer = null
+    this.websocketConnected = false
+
+    // Check if Turbo cable subscription is active
+    this.checkWebSocket()
+  }
+
+  disconnect() {
+    this.stopPolling()
+  }
+
+  // Called when the turbo frame inside is replaced by a broadcast
+  statusFrameTargetConnected(element) {
+    const status = element.dataset.status
+    const error = element.dataset.error
+
+    if (status === "completed") {
+      window.location.href = this.completedUrlValue
+    } else if (status === "failed") {
+      const failedUrl = new URL(this.failedUrlValue, window.location.origin)
+      if (error) {
+        failedUrl.searchParams.set("alert", `Operation failed: ${error}`)
+      }
+      window.location.href = failedUrl.toString()
+    }
+  }
+
+  checkWebSocket() {
+    // Give ActionCable a moment to connect, then start polling as fallback
+    setTimeout(() => {
+      if (!this.websocketConnected) {
+        this.startPolling()
+      }
+    }, 3000)
+
+    // Listen for ActionCable connection events
+    if (window.Turbo && window.Turbo.connectStreamSource) {
+      this.websocketConnected = true
+    }
+
+    // Also detect via cable consumer
+    const cable = document.querySelector("[data-turbo-stream-source]")
+    if (cable) {
+      this.websocketConnected = true
+    }
+  }
+
+  startPolling() {
+    if (this.pollTimer) return
+    if (!this.hasPollUrlValue) return
+
+    this.pollTimer = setInterval(() => {
+      this.poll()
+    }, this.pollIntervalValue)
+  }
+
+  stopPolling() {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer)
+      this.pollTimer = null
+    }
+  }
+
+  async poll() {
+    try {
+      const response = await fetch(this.pollUrlValue, {
+        headers: { "Accept": "text/html" }
+      })
+
+      if (response.redirected) {
+        window.location.href = response.url
+        this.stopPolling()
+        return
+      }
+
+      if (response.ok) {
+        const html = await response.text()
+        const parser = new DOMParser()
+        const doc = parser.parseFromString(html, "text/html")
+        const frame = doc.querySelector("turbo-frame")
+
+        if (frame) {
+          const status = frame.querySelector("[data-status]")?.dataset?.status
+          if (status === "completed") {
+            window.location.href = this.completedUrlValue
+            this.stopPolling()
+          } else if (status === "failed") {
+            window.location.href = this.failedUrlValue
+            this.stopPolling()
+          }
+        }
+      }
+    } catch {
+      // Network error — keep polling
+    }
+  }
+}

--- a/app/models/ai_task_status.rb
+++ b/app/models/ai_task_status.rb
@@ -20,6 +20,7 @@ class AiTaskStatus < ApplicationRecord
 
   validate :validate_status_transition, if: :status_changed?, unless: :new_record?
 
+  after_update_commit :broadcast_progress, if: :saved_change_to_progress_percentage?
   after_update_commit :broadcast_status_change, if: :saved_change_to_status?
 
   def mark_processing!
@@ -47,7 +48,15 @@ class AiTaskStatus < ApplicationRecord
     errors.add(:status, "cannot transition from #{status_was} to #{status}")
   end
 
+  def broadcast_progress
+    broadcast_update
+  end
+
   def broadcast_status_change
+    broadcast_update
+  end
+
+  def broadcast_update
     broadcast_replace_to(
       [ account, :ai_task_statuses ],
       target: "ai_task_status_#{id}",

--- a/app/views/accounts/meal_plans/generate_status.html.erb
+++ b/app/views/accounts/meal_plans/generate_status.html.erb
@@ -1,49 +1,15 @@
 <% content_for(:title, "Generating Meal Plan - MealSzn") %>
 
-<div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8 text-center">
-  <h1 class="font-display font-bold text-3xl text-warm-900 mb-4">Generating Your Meal Plan...</h1>
-
-  <div class="bg-white rounded-lg shadow p-8 space-y-6">
-    <div class="flex justify-center">
-      <div class="relative">
-        <svg class="animate-spin h-16 w-16 text-primary-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-        </svg>
-        <div class="absolute inset-0 flex items-center justify-center">
-          <svg class="w-6 h-6 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456z" />
-          </svg>
-        </div>
-      </div>
-    </div>
-
-    <div>
-      <p class="text-warm-700 text-lg font-medium mb-1">
-        <% if @task.progress_percentage < 20 %>
-          Analyzing your recipe catalog...
-        <% elsif @task.progress_percentage < 50 %>
-          Building your personalized meal plan...
-        <% elsif @task.progress_percentage < 80 %>
-          Optimizing meals for nutrition balance...
-        <% else %>
-          Finalizing portions and wrapping up...
-        <% end %>
-      </p>
-      <p class="text-warm-500 text-sm">
-        AI is selecting the best recipes for your dietary goals.
-      </p>
-    </div>
-
-    <div class="w-full bg-warm-200 rounded-full h-2.5">
-      <div class="bg-primary-600 h-2.5 rounded-full transition-all duration-700 ease-out" style="width: <%= @task.progress_percentage %>%"></div>
-    </div>
-
-    <p class="text-sm text-warm-400"><%= @task.progress_percentage %>% complete</p>
-  </div>
-</div>
-
-<%= tag.meta name: "turbo-refresh-scroll", content: "preserve" %>
-<script>
-  setTimeout(function() { window.location.reload(); }, 2000);
-</script>
+<%= render "shared/ai_progress",
+  task: @task,
+  title: "Generating Your Meal Plan...",
+  subtitle: "AI is selecting the best recipes for your dietary goals.",
+  completed_url: meal_plan_path(@meal_plan),
+  failed_url: meal_plan_path(@meal_plan),
+  poll_url: generate_status_meal_plans_path(task_id: @task.id, meal_plan_id: @meal_plan.id),
+  milestones: {
+    0 => "Analyzing your recipe catalog...",
+    20 => "Building your personalized meal plan...",
+    50 => "Optimizing meals for nutrition balance...",
+    80 => "Finalizing portions and wrapping up..."
+  } %>

--- a/app/views/accounts/recipes/import_status.html.erb
+++ b/app/views/accounts/recipes/import_status.html.erb
@@ -1,30 +1,7 @@
-<div class="max-w-2xl mx-auto text-center">
-  <h1 class="font-display font-bold text-3xl text-warm-900 mb-4">Importing Recipe...</h1>
-
-  <div class="card-warm p-8 space-y-6">
-    <div class="flex justify-center">
-      <svg class="animate-spin h-12 w-12 text-primary-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-      </svg>
-    </div>
-
-    <p class="text-warm-600 text-lg">
-      We're extracting the recipe details. This usually takes a few seconds.
-    </p>
-
-    <div class="w-full bg-warm-200 rounded-full h-2">
-      <div class="bg-primary-600 h-2 rounded-full transition-all duration-500" style="width: <%= @task.progress_percentage %>%"></div>
-    </div>
-
-    <p class="text-sm text-warm-500"><%= @task.progress_percentage %>% complete</p>
-  </div>
-</div>
-
-<%= tag.meta name: "turbo-refresh-scroll", content: "preserve" %>
-<script>
-  // Poll for completion
-  setTimeout(function() {
-    window.location.reload();
-  }, 2000);
-</script>
+<%= render "shared/ai_progress",
+  task: @task,
+  title: "Importing Recipe...",
+  subtitle: "We're extracting the recipe details. This usually takes a few seconds.",
+  completed_url: import_review_recipes_path(task_id: @task.id),
+  failed_url: @failed_url,
+  poll_url: import_status_recipes_path(task_id: @task.id) %>

--- a/app/views/ai_task_statuses/_ai_task_status.html.erb
+++ b/app/views/ai_task_statuses/_ai_task_status.html.erb
@@ -1,5 +1,12 @@
 <%= turbo_frame_tag "ai_task_status_#{ai_task_status.id}" do %>
-  <div data-status="<%= ai_task_status.status %>" data-progress="<%= ai_task_status.progress_percentage %>">
-    <%= ai_task_status.status.humanize %> — <%= ai_task_status.progress_percentage %>%
+  <div data-ai-progress-target="statusFrame"
+       data-status="<%= ai_task_status.status %>"
+       data-progress="<%= ai_task_status.progress_percentage %>"
+       data-error="<%= ai_task_status.error_message %>">
+    <div class="w-full bg-warm-200 rounded-full h-2.5 overflow-hidden">
+      <div class="bg-primary-600 h-2.5 rounded-full transition-all duration-700 ease-out"
+           style="width: <%= ai_task_status.progress_percentage %>%"></div>
+    </div>
+    <p class="text-sm text-warm-400 mt-2"><%= ai_task_status.progress_percentage %>% complete</p>
   </div>
 <% end %>

--- a/app/views/shared/_ai_progress.html.erb
+++ b/app/views/shared/_ai_progress.html.erb
@@ -1,0 +1,50 @@
+<%# Reusable AI progress partial
+     locals:
+       task          - AiTaskStatus instance
+       title         - heading text (e.g. "Importing Recipe...")
+       subtitle      - description below the spinner
+       completed_url - redirect URL on completion
+       failed_url    - redirect URL on failure
+       poll_url      - fallback polling URL
+       milestones    - optional hash of { percentage_threshold => message } for contextual status text
+%>
+<% milestones ||= {} %>
+
+<%= turbo_stream_from Current.account, :ai_task_statuses %>
+
+<div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8 text-center"
+     data-controller="ai-progress"
+     data-ai-progress-poll-url-value="<%= poll_url %>"
+     data-ai-progress-completed-url-value="<%= completed_url %>"
+     data-ai-progress-failed-url-value="<%= failed_url %>">
+
+  <h1 class="font-display font-bold text-3xl text-warm-900 mb-4"><%= title %></h1>
+
+  <div class="bg-white rounded-lg shadow p-8 space-y-6">
+    <div class="flex justify-center">
+      <div class="relative">
+        <svg class="animate-spin h-16 w-16 text-primary-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        </svg>
+        <div class="absolute inset-0 flex items-center justify-center">
+          <svg class="w-6 h-6 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456z" />
+          </svg>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <% if milestones.any? %>
+        <p class="text-warm-700 text-lg font-medium mb-1">
+          <% milestone_message = milestones.sort_by { |k, _| -k }.find { |k, _| task.progress_percentage >= k }&.last %>
+          <%= milestone_message || subtitle %>
+        </p>
+      <% end %>
+      <p class="text-warm-500 text-sm"><%= subtitle %></p>
+    </div>
+
+    <%= render partial: "ai_task_statuses/ai_task_status", locals: { ai_task_status: task } %>
+  </div>
+</div>

--- a/test/models/ai_task_status_test.rb
+++ b/test/models/ai_task_status_test.rb
@@ -144,11 +144,19 @@ class AiTaskStatusTest < ActiveSupport::TestCase
     end
   end
 
-  test "does not broadcast when non-status attributes change" do
+  test "broadcasts when progress percentage changes" do
+    task = ai_task_statuses(:processing_task)
+
+    assert_turbo_stream_broadcasts([ task.account, :ai_task_statuses ]) do
+      task.update!(progress_percentage: 75)
+    end
+  end
+
+  test "does not broadcast when non-progress non-status attributes change" do
     task = ai_task_statuses(:processing_task)
 
     assert_no_turbo_stream_broadcasts([ task.account, :ai_task_statuses ]) do
-      task.update!(progress_percentage: 75)
+      task.update!(error_message: "some note")
     end
   end
 end


### PR DESCRIPTION
## Summary

Replaces the `setTimeout` page-reload polling on AI progress pages with real-time Turbo Stream updates via Action Cable. Progress bars now update smoothly without full page reloads, and the user is automatically redirected when the task completes or fails.

## Changes

- `AiTaskStatus` now broadcasts on `progress_percentage` changes (previously only on status changes)
- New `ai_progress_controller.js` Stimulus controller — watches broadcast partial for status changes, redirects on completion/failure, falls back to 2s polling if WebSocket unavailable
- New reusable `shared/_ai_progress.html.erb` partial — accepts task, title, subtitle, URLs, and optional milestone messages
- Enhanced `ai_task_statuses/_ai_task_status.html.erb` broadcast partial with progress bar and Stimulus data attributes
- Simplified `import_status.html.erb` and `generate_status.html.erb` to use the shared partial
- Updated test to verify broadcasts on progress changes

## Documentation

- CLAUDE.md: Updated AI Background Jobs section to document real-time progress UI pattern

## Testing

- 924 tests, 0 failures
- Rubocop: 0 offenses
- Brakeman: 0 warnings
- Updated `AiTaskStatusTest` to verify progress broadcasts and ensure non-progress attributes don't broadcast

Closes #27