### PR TITLE
USDA Nutrition Data API integration for automatic macro calculation

### DIFF
--- a/app/controllers/accounts/api/v1/recipes_controller.rb
+++ b/app/controllers/accounts/api/v1/recipes_controller.rb
@@ -1,8 +1,8 @@
 class Accounts::Api::V1::RecipesController < Accounts::Api::V1::ApplicationController
   include AiRateLimited
 
-  before_action :require_write_permission!, only: %i[create update destroy import_url import_photo import_confirm]
-  before_action :set_recipe, only: %i[show update destroy]
+  before_action :require_write_permission!, only: %i[create update destroy import_url import_photo import_confirm calculate_nutrition]
+  before_action :set_recipe, only: %i[show update destroy calculate_nutrition]
   before_action :set_task, only: %i[import_status import_confirm]
   before_action -> { check_ai_rate_limit!(:recipe_import) }, only: %i[import_url import_photo]
 
@@ -57,6 +57,28 @@ class Accounts::Api::V1::RecipesController < Accounts::Api::V1::ApplicationContr
   def destroy
     @recipe.destroy
     head :no_content
+  end
+
+  # POST /api/v1/recipes/:id/calculate_nutrition
+  def calculate_nutrition
+    if @recipe.ingredients.none?
+      render json: { error: "Recipe has no ingredients" }, status: :unprocessable_entity
+      return
+    end
+
+    result = Nutrition::Calculator.new(@recipe.reload).calculate
+
+    if result.success?
+      nutrition = @recipe.nutrition_data || @recipe.build_nutrition_data
+      nutrition.update!(result.nutrition_data)
+      render json: { recipe: @recipe.reload.to_api_response }
+    else
+      unresolved_names = result.unresolved_ingredients.map(&:name)
+      render json: {
+        error: "Could not resolve all ingredients",
+        unresolved_ingredients: unresolved_names
+      }, status: :unprocessable_entity
+    end
   end
 
   # POST /api/v1/recipes/import_url

--- a/app/jobs/nutrition_calculation_job.rb
+++ b/app/jobs/nutrition_calculation_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class NutritionCalculationJob < ApplicationJob
+  queue_as :default
+
+  discard_on ActiveRecord::RecordNotFound
+
+  def perform(recipe_id)
+    recipe = Recipe.includes(:ingredients, :nutrition_data).find(recipe_id)
+
+    return if recipe.ingredients.none?
+
+    result = Nutrition::Calculator.new(recipe).calculate
+    return unless result.success?
+
+    nutrition = recipe.nutrition_data || recipe.build_nutrition_data
+    nutrition.update!(result.nutrition_data)
+  end
+end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -24,6 +24,8 @@ class Recipe < ApplicationRecord
   validate :validate_image_attachment
   validate :validate_images_attachments
 
+  after_commit :enqueue_nutrition_calculation, on: [ :create, :update ], if: :should_auto_calculate_nutrition?
+
   enum :category, {
     breakfast: 0,
     lunch: 1,
@@ -144,6 +146,17 @@ class Recipe < ApplicationRecord
   end
 
   private
+
+  def enqueue_nutrition_calculation
+    NutritionCalculationJob.perform_later(id)
+  end
+
+  def should_auto_calculate_nutrition?
+    # Skip if nutrition was manually provided or no ingredients exist
+    return false if ingredients.none?
+    return false if nutrition_data.present? && !nutrition_data.auto_calculated?
+    true
+  end
 
   def validate_image_attachment
     validate_single_image(image, :image) if image.attached?

--- a/app/services/nutrition/calculator.rb
+++ b/app/services/nutrition/calculator.rb
@@ -6,8 +6,9 @@ module Nutrition
 
     SKIPPABLE_UNITS = %w[pinch dash].freeze
 
-    def initialize(recipe)
+    def initialize(recipe, usda_client: nil)
       @recipe = recipe
+      @usda_client = usda_client
     end
 
     def calculate
@@ -78,6 +79,32 @@ module Nutrition
         return item
       end
 
+      # Fall back to USDA API search
+      item = search_usda_for(ingredient)
+      if item
+        ingredient.update_columns(nutrition_item_id: item.id)
+        return item
+      end
+
+      nil
+    end
+
+    def search_usda_for(ingredient)
+      client = @usda_client || Usda::Client.new
+      search_term = NutritionItem.normalize_name(ingredient.name)
+      result = client.search(search_term, page_size: 1)
+
+      foods = result["foods"]
+      return nil if foods.blank?
+
+      # Import the top match and create an alias
+      item = Usda::FoodImporter.new(foods.first).import
+      NutritionItem::Alias.find_or_create_by!(name: search_term) do |a|
+        a.nutrition_item = item
+      end
+      item
+    rescue Usda::Client::ApiError, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError, SocketError, Errno::ECONNREFUSED => e
+      Rails.logger.warn("[Nutrition::Calculator] USDA search failed for '#{ingredient.name}': #{e.message}")
       nil
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,9 @@ Rails.application.routes.draw do
       namespace :v1 do
         # RecipeScanner iOS API
         resources :recipes, only: %i[index show create update destroy] do
+          member do
+            post :calculate_nutrition
+          end
           collection do
             post :import_url
             post :import_photo

--- a/test/controllers/accounts/api/v1/recipes_controller_test.rb
+++ b/test/controllers/accounts/api/v1/recipes_controller_test.rb
@@ -165,4 +165,51 @@ class Accounts::Api::V1::RecipesControllerTest < ActionDispatch::IntegrationTest
     json = JSON.parse(response.body)
     assert_includes json["errors"], "Title can't be blank"
   end
+
+  test "calculate_nutrition returns nutrition for recipe with resolved ingredients" do
+    recipe = @account.recipes.create!(title: "Calc Test", category: :breakfast, servings: 2)
+    egg_item = nutrition_items(:egg)
+    recipe.ingredients.create!(name: "Eggs", quantity: "4", unit: "large", nutrition_item: egg_item, display_order: 0)
+
+    post "/#{@account.external_account_id}/api/v1/recipes/#{recipe.id}/calculate_nutrition",
+         headers: auth_header(@write_token),
+         as: :json
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert json["recipe"]["nutrition"].present?
+    assert json["recipe"]["nutrition"]["calories"] > 0
+  end
+
+  test "calculate_nutrition returns error for recipe with no ingredients" do
+    recipe = @account.recipes.create!(title: "Empty", category: :dinner)
+
+    post "/#{@account.external_account_id}/api/v1/recipes/#{recipe.id}/calculate_nutrition",
+         headers: auth_header(@write_token),
+         as: :json
+
+    assert_response :unprocessable_entity
+    json = JSON.parse(response.body)
+    assert_equal "Recipe has no ingredients", json["error"]
+  end
+
+  test "calculate_nutrition returns unresolved ingredients" do
+    @recipe.ingredients.create!(name: "Unknown exotic thing", quantity: "1", unit: "cup", display_order: 0)
+
+    post "/#{@account.external_account_id}/api/v1/recipes/#{@recipe.id}/calculate_nutrition",
+         headers: auth_header(@write_token),
+         as: :json
+
+    assert_response :unprocessable_entity
+    json = JSON.parse(response.body)
+    assert json["unresolved_ingredients"].present?
+  end
+
+  test "calculate_nutrition requires write permission" do
+    post "/#{@account.external_account_id}/api/v1/recipes/#{@recipe.id}/calculate_nutrition",
+         headers: auth_header(@read_token),
+         as: :json
+
+    assert_response :forbidden
+  end
 end

--- a/test/jobs/nutrition_calculation_job_test.rb
+++ b/test/jobs/nutrition_calculation_job_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+
+class NutritionCalculationJobTest < ActiveJob::TestCase
+  setup do
+    @account = accounts(:one)
+    @recipe = @account.recipes.create!(
+      title: "Test Recipe",
+      category: :breakfast,
+      servings: 2
+    )
+  end
+
+  test "calculates and saves nutrition data for recipe" do
+    egg_item = nutrition_items(:egg)
+    @recipe.ingredients.create!(name: "Eggs", quantity: "4", unit: "large", nutrition_item: egg_item)
+
+    NutritionCalculationJob.perform_now(@recipe.id)
+
+    @recipe.reload
+    assert @recipe.nutrition_data.present?
+    assert @recipe.nutrition_data.auto_calculated?
+    assert @recipe.nutrition_data.calories > 0
+  end
+
+  test "does nothing for recipe with no ingredients" do
+    NutritionCalculationJob.perform_now(@recipe.id)
+
+    @recipe.reload
+    assert_nil @recipe.nutrition_data
+  end
+
+  test "does nothing when ingredients are unresolved" do
+    @recipe.ingredients.create!(name: "Unknown exotic thing", quantity: "1", unit: "cup")
+
+    NutritionCalculationJob.perform_now(@recipe.id)
+
+    @recipe.reload
+    assert_nil @recipe.nutrition_data
+  end
+
+  test "discards job for missing recipe" do
+    assert_nothing_raised do
+      NutritionCalculationJob.perform_now("nonexistent-id")
+    end
+  end
+
+  test "updates existing auto-calculated nutrition data" do
+    egg_item = nutrition_items(:egg)
+    @recipe.ingredients.create!(name: "Eggs", quantity: "2", unit: "large", nutrition_item: egg_item)
+
+    NutritionCalculationJob.perform_now(@recipe.id)
+    @recipe.reload
+    original_calories = @recipe.nutrition_data.calories
+
+    # Add more ingredients and recalculate
+    butter_item = nutrition_items(:butter)
+    @recipe.ingredients.create!(name: "Butter", quantity: "2", unit: "tbsp", nutrition_item: butter_item)
+
+    NutritionCalculationJob.perform_now(@recipe.id)
+    @recipe.reload
+    assert @recipe.nutrition_data.calories > original_calories
+  end
+end

--- a/test/models/recipe_test.rb
+++ b/test/models/recipe_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class RecipeTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   test "belongs to account" do
     recipe = recipes(:one)
     assert_respond_to recipe, :account
@@ -282,5 +284,41 @@ class RecipeTest < ActiveSupport::TestCase
 
     assert response[:tags].is_a?(Array)
     assert_includes response[:tags], "keto"
+  end
+
+  test "enqueues nutrition calculation job on create with ingredients" do
+    account = accounts(:one)
+
+    assert_enqueued_with(job: NutritionCalculationJob) do
+      account.recipes.create!(
+        title: "Auto Calc Recipe",
+        category: :breakfast,
+        servings: 2,
+        ingredients_attributes: [
+          { name: "Eggs", quantity: "2", unit: "large", display_order: 0 }
+        ]
+      )
+    end
+  end
+
+  test "does not enqueue nutrition calculation job without ingredients" do
+    account = accounts(:one)
+
+    assert_no_enqueued_jobs(only: NutritionCalculationJob) do
+      account.recipes.create!(
+        title: "Empty Recipe",
+        category: :breakfast,
+        servings: 2
+      )
+    end
+  end
+
+  test "does not enqueue nutrition calculation when manual nutrition exists" do
+    recipe = recipes(:one)
+    # recipes(:one) has nutrition_data with auto_calculated: false
+
+    assert_no_enqueued_jobs(only: NutritionCalculationJob) do
+      recipe.update!(title: "Updated Title")
+    end
   end
 end

--- a/test/services/nutrition/calculator_test.rb
+++ b/test/services/nutrition/calculator_test.rb
@@ -1,5 +1,24 @@
 require "test_helper"
 
+class FakeUsdaClientForCalculator
+  attr_reader :search_result, :should_error
+
+  def initialize(search_result: nil, should_error: false)
+    @search_result = search_result
+    @should_error = should_error
+  end
+
+  def search(query, page_size: 10)
+    raise Usda::Client::ApiError, "API error" if should_error
+    search_result
+  end
+
+  def food(fdc_id)
+    raise Usda::Client::ApiError, "API error" if should_error
+    {}
+  end
+end
+
 class Nutrition::CalculatorTest < ActiveSupport::TestCase
   setup do
     @account = accounts(:one)
@@ -28,9 +47,10 @@ class Nutrition::CalculatorTest < ActiveSupport::TestCase
   end
 
   test "returns unresolved when ingredients not matched" do
+    no_results_client = FakeUsdaClientForCalculator.new(search_result: { "foods" => [] })
     @recipe.ingredients.create!(name: "Unknown Food", quantity: "1", unit: "cup")
 
-    result = Nutrition::Calculator.new(@recipe.reload).calculate
+    result = Nutrition::Calculator.new(@recipe.reload, usda_client: no_results_client).calculate
     assert_not result.success?
     assert_equal 1, result.unresolved_ingredients.size
     assert_equal "Unknown Food", result.unresolved_ingredients.first.name
@@ -85,5 +105,58 @@ class Nutrition::CalculatorTest < ActiveSupport::TestCase
     result = Nutrition::Calculator.new(@recipe.reload).calculate
     # nil quantity is skipped, not unresolved
     assert result.success?
+  end
+
+  test "falls back to USDA API search when alias lookup fails" do
+    fake_client = FakeUsdaClientForCalculator.new(
+      search_result: {
+        "foods" => [ {
+          "fdcId" => 999999,
+          "description" => "Chicken, breast, raw",
+          "foodNutrients" => [
+            { "nutrient" => { "id" => 1008 }, "amount" => 165 },
+            { "nutrient" => { "id" => 1004 }, "amount" => 3.6 },
+            { "nutrient" => { "id" => 1003 }, "amount" => 31.0 },
+            { "nutrient" => { "id" => 1005 }, "amount" => 0.0 },
+            { "nutrient" => { "id" => 1079 }, "amount" => 0.0 }
+          ]
+        } ]
+      }
+    )
+
+    @recipe.ingredients.create!(name: "Chicken breast", quantity: "200", unit: "g")
+
+    result = Nutrition::Calculator.new(@recipe.reload, usda_client: fake_client).calculate
+    assert result.success?
+
+    # Verify ingredient was linked
+    ingredient = @recipe.ingredients.first.reload
+    assert_not_nil ingredient.nutrition_item_id
+
+    # Verify alias was created
+    assert_not_nil NutritionItem::Alias.find_by(name: "chicken breast")
+
+    # 200g of chicken breast (165 cal per 100g) = 330 total, 165 per serving (2 servings)
+    assert_in_delta 165, result.nutrition_data[:calories], 1
+  end
+
+  test "handles USDA API error gracefully" do
+    error_client = FakeUsdaClientForCalculator.new(should_error: true)
+
+    @recipe.ingredients.create!(name: "Unknown exotic ingredient", quantity: "1", unit: "cup")
+
+    result = Nutrition::Calculator.new(@recipe.reload, usda_client: error_client).calculate
+    assert_not result.success?
+    assert_equal 1, result.unresolved_ingredients.size
+  end
+
+  test "handles USDA API returning no results" do
+    empty_client = FakeUsdaClientForCalculator.new(search_result: { "foods" => [] })
+
+    @recipe.ingredients.create!(name: "Nonexistent food xyz", quantity: "1", unit: "cup")
+
+    result = Nutrition::Calculator.new(@recipe.reload, usda_client: empty_client).calculate
+    assert_not result.success?
+    assert_equal 1, result.unresolved_ingredients.size
   end
 end


### PR DESCRIPTION
## Summary

- Adds automatic USDA API fallback in `Nutrition::Calculator` when alias lookup fails — searches USDA, imports the best match, creates aliases for future lookups
- Introduces `NutritionCalculationJob` background job that runs after recipe create/update to auto-calculate nutrition from ingredients
- Adds `POST /:account_id/api/v1/recipes/:id/calculate_nutrition` API endpoint for on-demand nutrition recalculation
- Respects manually-entered nutrition data — auto-calculation only runs when `auto_calculated` flag is true or no nutrition data exists

## Changes

- `app/services/nutrition/calculator.rb` — Added USDA API search fallback with error handling for network failures
- `app/jobs/nutrition_calculation_job.rb` — New background job for async nutrition calculation
- `app/models/recipe.rb` — `after_commit` callback to enqueue job when ingredients change
- `app/controllers/accounts/api/v1/recipes_controller.rb` — New `calculate_nutrition` endpoint
- `config/routes.rb` — Added member route for `calculate_nutrition`

## Testing

- 939 tests pass (15 new tests added)
- Calculator: USDA API fallback, error handling, empty results
- Job: success path, no ingredients, unresolved ingredients, missing recipe
- Model: callback enqueuing with/without ingredients, manual nutrition guard
- API: calculate_nutrition endpoint (success, no ingredients, unresolved, permissions)
- Rubocop: 0 offenses in changed files
- Brakeman: 0 warnings

Closes #62