### PR TITLE
Add AI request instrumentation and metrics dashboard

### DIFF
--- a/app/controllers/accounts/ai_metrics_controller.rb
+++ b/app/controllers/accounts/ai_metrics_controller.rb
@@ -1,0 +1,38 @@
+class Accounts::AiMetricsController < ApplicationController
+  before_action :require_admin!
+
+  def index
+    @period = params[:period] || "24h"
+    @since = period_to_time(@period)
+
+    @total_requests = metrics_scope.count
+    @cache_hit_rate = AiRequestMetric.cache_hit_rate(since: @since)
+    @avg_duration = AiRequestMetric.average_duration(since: @since)
+    @tokens = AiRequestMetric.total_tokens_used(since: @since)
+    @feature_breakdown = AiRequestMetric.feature_breakdown(since: @since)
+    @error_count = metrics_scope.failed.count
+    @recent = metrics_scope.recent.limit(25)
+  end
+
+  private
+
+  def require_admin!
+    unless Current.user&.has_role_at_least?(:admin)
+      redirect_to account_root_path, alert: "Access denied."
+    end
+  end
+
+  def metrics_scope
+    Current.account.ai_request_metrics.since(@since)
+  end
+
+  def period_to_time(period)
+    case period
+    when "1h" then 1.hour.ago
+    when "24h" then 24.hours.ago
+    when "7d" then 7.days.ago
+    when "30d" then 30.days.ago
+    else 24.hours.ago
+    end
+  end
+end

--- a/app/jobs/diet_categorization_job.rb
+++ b/app/jobs/diet_categorization_job.rb
@@ -61,7 +61,7 @@ class DietCategorizationJob < AiBaseJob
                     "1.0 = perfect fit, 0.0 = completely incompatible. " \
                     "Be conservative — only score above 0.7 if the recipe clearly fits the diet."
 
-    result = client.chat_with_tools(messages: messages, tools: tools, system: system_prompt)
+    result = client.chat_with_tools(messages: messages, tools: tools, system: system_prompt, feature: "diet_categorization")
     normalize_ai_scores(result[:input])
   end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -11,6 +11,7 @@ class Account < ApplicationRecord
   has_many :meal_plans, dependent: :destroy
   has_many :dietary_profiles, dependent: :destroy
   has_many :ai_task_statuses, dependent: :destroy
+  has_many :ai_request_metrics, dependent: :destroy
 
   validates :name, presence: true
   validates :external_account_id, presence: true, uniqueness: true

--- a/app/models/ai_request_metric.rb
+++ b/app/models/ai_request_metric.rb
@@ -1,0 +1,77 @@
+class AiRequestMetric < ApplicationRecord
+  include Identifiable
+
+  belongs_to :account, optional: true
+
+  validates :feature, presence: true
+  validates :model, presence: true
+  validates :method_name, presence: true
+
+  scope :recent, -> { order(created_at: :desc) }
+  scope :for_feature, ->(feature) { where(feature: feature) }
+  scope :cache_hits, -> { where(cache_hit: true) }
+  scope :cache_misses, -> { where(cache_hit: false) }
+  scope :successful, -> { where(error_class: nil) }
+  scope :failed, -> { where.not(error_class: nil) }
+  scope :since, ->(time) { where("created_at >= ?", time) }
+
+  FEATURES = %w[meal_plan_generation recipe_import recipe_photo_import recipe_quick_entry nutrition_calculation].freeze
+
+  def total_input_tokens
+    input_tokens + cache_creation_input_tokens + cache_read_input_tokens
+  end
+
+  def cache_savings_tokens
+    cache_read_input_tokens
+  end
+
+  # Approximate cost savings based on Anthropic's cache pricing
+  # Cache reads are 90% cheaper than regular input tokens
+  def estimated_cache_savings_ratio
+    return 0.0 if total_input_tokens.zero?
+    cache_read_input_tokens.to_f / total_input_tokens
+  end
+
+  class << self
+    def cache_hit_rate(since: 24.hours.ago)
+      metrics = where("created_at >= ?", since).successful
+      total = metrics.count
+      return 0.0 if total.zero?
+      hits = metrics.cache_hits.count
+      (hits.to_f / total * 100).round(1)
+    end
+
+    def average_duration(since: 24.hours.ago)
+      where("created_at >= ?", since)
+        .successful
+        .where.not(duration_ms: nil)
+        .average(:duration_ms)
+        &.round(0) || 0
+    end
+
+    def total_tokens_used(since: 24.hours.ago)
+      metrics = where("created_at >= ?", since).successful
+      {
+        input: metrics.sum(:input_tokens),
+        output: metrics.sum(:output_tokens),
+        cache_creation: metrics.sum(:cache_creation_input_tokens),
+        cache_read: metrics.sum(:cache_read_input_tokens)
+      }
+    end
+
+    def feature_breakdown(since: 24.hours.ago)
+      where("created_at >= ?", since)
+        .successful
+        .group(:feature)
+        .select(
+          "feature",
+          "COUNT(*) as request_count",
+          "SUM(input_tokens) as total_input",
+          "SUM(output_tokens) as total_output",
+          "SUM(cache_read_input_tokens) as total_cache_read",
+          "SUM(cache_creation_input_tokens) as total_cache_creation",
+          "AVG(duration_ms) as avg_duration"
+        )
+    end
+  end
+end

--- a/app/models/concerns/user/role.rb
+++ b/app/models/concerns/user/role.rb
@@ -7,10 +7,11 @@ module User::Role
     scope :owners, -> { active.where(role: :owner) }
     scope :admins, -> { active.where(role: [ :owner, :admin ]) }
     scope :members, -> { active.where(role: :member) }
-  end
 
-  def admin?
-    owner? || read_attribute(:role) == "admin"
+    # Override the enum-generated admin? to include owners
+    define_method(:admin?) do
+      owner? || read_attribute(:role) == "admin"
+    end
   end
 
   def can_change?(other)

--- a/app/services/ai/client.rb
+++ b/app/services/ai/client.rb
@@ -11,9 +11,12 @@ module Ai
     MAX_RETRIES = 3
     RETRY_DELAYS = [ 1, 2, 4 ].freeze
 
+    attr_reader :model_name
+
     def initialize(api_key: nil, model: nil)
       @api_key = api_key || Rails.application.credentials.dig(:ai, :anthropic, :api_key)
       @model = model || Ai.default_model
+      @model_name = @model
 
       raise AuthenticationError, "Anthropic API key is not configured" if @api_key.blank?
     end
@@ -23,10 +26,13 @@ module Ai
     # @param messages [Array<Hash>] Conversation messages, e.g. [{role: "user", content: "Hello"}]
     # @param system [String, nil] Optional system prompt
     # @param max_tokens [Integer] Maximum tokens to generate
+    # @param feature [String, nil] Feature name for instrumentation
     # @return [String] The assistant's text response
-    def chat(messages:, system: nil, max_tokens: 1024)
+    def chat(messages:, system: nil, max_tokens: 1024, feature: nil)
       params = build_params(messages:, system:, max_tokens:)
-      response = with_retries { anthropic_client.messages.create(**params) }
+      response = instrument(:chat, feature:) do
+        with_retries { anthropic_client.messages.create(**params) }
+      end
       extract_text(response)
     end
 
@@ -36,13 +42,16 @@ module Ai
     # @param tools [Array<Hash>] Tool definitions with name, description, input_schema
     # @param system [String, nil] Optional system prompt
     # @param max_tokens [Integer] Maximum tokens to generate
+    # @param feature [String, nil] Feature name for instrumentation
     # @return [Hash] Parsed tool input from the model's tool_use response
-    def chat_with_tools(messages:, tools:, system: nil, max_tokens: 4096)
+    def chat_with_tools(messages:, tools:, system: nil, max_tokens: 4096, feature: nil)
       params = build_params(messages:, system:, max_tokens:)
       params[:tools] = tools
       params[:tool_choice] = { type: "any" }
 
-      response = with_retries { anthropic_client.messages.create(**params) }
+      response = instrument(:chat_with_tools, feature:) do
+        with_retries { anthropic_client.messages.create(**params) }
+      end
       extract_tool_use(response)
     end
 
@@ -51,9 +60,10 @@ module Ai
     # @param messages [Array<Hash>] Messages with image content blocks
     # @param system [String, nil] Optional system prompt
     # @param max_tokens [Integer] Maximum tokens to generate
+    # @param feature [String, nil] Feature name for instrumentation
     # @return [String] The assistant's text response
-    def vision(messages:, system: nil, max_tokens: 1024)
-      chat(messages:, system:, max_tokens:)
+    def vision(messages:, system: nil, max_tokens: 1024, feature: nil)
+      chat(messages:, system:, max_tokens:, feature:)
     end
 
     private
@@ -70,6 +80,44 @@ module Ai
       }
       params[:system] = system if system.present?
       params
+    end
+
+    def instrument(method_name, feature: nil)
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      error = nil
+
+      begin
+        response = yield
+      rescue => e
+        error = e
+        raise
+      ensure
+        duration_ms = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000
+        usage = extract_usage(response) if response
+
+        ActiveSupport::Notifications.instrument("request.ai_client", {
+          model: @model,
+          method_name: method_name.to_s,
+          feature: feature,
+          duration_ms: duration_ms.round(1),
+          usage: usage || {},
+          error: error
+        })
+      end
+
+      response
+    end
+
+    def extract_usage(response)
+      usage = response.try(:usage)
+      return {} unless usage
+
+      {
+        input_tokens: usage.try(:input_tokens) || 0,
+        output_tokens: usage.try(:output_tokens) || 0,
+        cache_creation_input_tokens: usage.try(:cache_creation_input_tokens) || 0,
+        cache_read_input_tokens: usage.try(:cache_read_input_tokens) || 0
+      }
     end
 
     def with_retries(&block)

--- a/app/services/ai/instrumentation.rb
+++ b/app/services/ai/instrumentation.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Ai
+  class Instrumentation
+    def self.subscribe!
+      ActiveSupport::Notifications.subscribe("request.ai_client") do |event|
+        new.record(event)
+      end
+    end
+
+    def record(event)
+      payload = event.payload
+      usage = payload[:usage] || {}
+      error = payload[:error]
+
+      cache_read = usage[:cache_read_input_tokens] || 0
+      cache_creation = usage[:cache_creation_input_tokens] || 0
+      cache_hit = cache_read > 0
+
+      attrs = {
+        account_id: Current.account&.id,
+        feature: payload[:feature] || "unknown",
+        model: payload[:model],
+        method_name: payload[:method_name],
+        input_tokens: usage[:input_tokens] || 0,
+        output_tokens: usage[:output_tokens] || 0,
+        cache_creation_input_tokens: cache_creation,
+        cache_read_input_tokens: cache_read,
+        duration_ms: payload[:duration_ms],
+        cache_hit: cache_hit
+      }
+
+      if error
+        attrs[:error_class] = error.class.name
+        attrs[:error_message] = error.message.truncate(500)
+      end
+
+      AiRequestMetric.create!(attrs)
+
+      log_metrics(attrs)
+    rescue => e
+      Rails.logger.error("[Ai::Instrumentation] Failed to record metric: #{e.message}")
+    end
+
+    private
+
+    def log_metrics(attrs)
+      log_data = {
+        ai_request: true,
+        feature: attrs[:feature],
+        model: attrs[:model],
+        method: attrs[:method_name],
+        duration_ms: attrs[:duration_ms],
+        input_tokens: attrs[:input_tokens],
+        output_tokens: attrs[:output_tokens],
+        cache_hit: attrs[:cache_hit],
+        cache_read_tokens: attrs[:cache_read_input_tokens],
+        cache_creation_tokens: attrs[:cache_creation_input_tokens]
+      }
+      log_data[:error] = attrs[:error_class] if attrs[:error_class]
+
+      Rails.logger.info("[Ai::Instrumentation] #{log_data.to_json}")
+    end
+  end
+end

--- a/app/services/meal_plan_generator.rb
+++ b/app/services/meal_plan_generator.rb
@@ -138,7 +138,8 @@ class MealPlanGenerator
       messages: [ { role: "user", content: user_message } ],
       tools: [ meal_plan_tool_definition ],
       system: system_prompt,
-      max_tokens: 4096
+      max_tokens: 4096,
+      feature: "meal_plan_generation"
     )
 
     unless result[:name] == "assign_meals"

--- a/app/services/recipe_import/ai_extractor.rb
+++ b/app/services/recipe_import/ai_extractor.rb
@@ -54,7 +54,8 @@ module RecipeImport
         messages: [ { role: "user", content: "Extract the recipe from this page:\n\n#{truncated}" } ],
         tools: [ RECIPE_TOOL ],
         system: SYSTEM_PROMPT,
-        max_tokens: 4096
+        max_tokens: 4096,
+        feature: "recipe_import"
       )
 
       normalize(result[:input])

--- a/app/services/recipe_import/ai_generator.rb
+++ b/app/services/recipe_import/ai_generator.rb
@@ -17,7 +17,8 @@ module RecipeImport
         messages: [ { role: "user", content: user_prompt } ],
         tools: [ RECIPE_TOOL ],
         system: system_prompt,
-        max_tokens: 4096
+        max_tokens: 4096,
+        feature: "recipe_quick_entry"
       )
 
       normalize(result[:input])

--- a/app/services/recipe_import/photo_extractor.rb
+++ b/app/services/recipe_import/photo_extractor.rb
@@ -31,7 +31,8 @@ module RecipeImport
         messages: [ { role: "user", content: content } ],
         tools: [ RECIPE_TOOL ],
         system: SYSTEM_PROMPT,
-        max_tokens: 4096
+        max_tokens: 4096,
+        feature: "recipe_photo_import"
       )
 
       normalize(result[:input])

--- a/app/views/accounts/ai_metrics/index.html.erb
+++ b/app/views/accounts/ai_metrics/index.html.erb
@@ -1,0 +1,136 @@
+<% content_for(:title, "AI Metrics - MealSzn") %>
+
+<div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <div class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-display font-bold text-warm-900">AI Request Metrics</h1>
+    <div class="flex gap-1 bg-warm-100 rounded-lg p-0.5">
+      <% %w[1h 24h 7d 30d].each do |period| %>
+        <%= link_to period, ai_metrics_path(period: period),
+            class: "px-3 py-1 text-sm font-medium rounded-md transition-colors #{@period == period ? 'bg-white text-primary-700 shadow-sm' : 'text-warm-600 hover:text-warm-800'}" %>
+      <% end %>
+    </div>
+  </div>
+
+  <%# Summary Cards %>
+  <div class="grid grid-cols-2 lg:grid-cols-5 gap-4 mb-8">
+    <div class="bg-white rounded-lg shadow p-4">
+      <p class="text-xs font-semibold text-warm-500 uppercase tracking-wider">Total Requests</p>
+      <p class="text-2xl font-display font-bold text-warm-900 mt-1"><%= @total_requests %></p>
+    </div>
+    <div class="bg-white rounded-lg shadow p-4">
+      <p class="text-xs font-semibold text-warm-500 uppercase tracking-wider">Cache Hit Rate</p>
+      <p class="text-2xl font-display font-bold <%= @cache_hit_rate >= 50 ? 'text-green-600' : @cache_hit_rate > 0 ? 'text-accent-600' : 'text-warm-400' %> mt-1"><%= @cache_hit_rate %>%</p>
+    </div>
+    <div class="bg-white rounded-lg shadow p-4">
+      <p class="text-xs font-semibold text-warm-500 uppercase tracking-wider">Avg Duration</p>
+      <p class="text-2xl font-display font-bold text-warm-900 mt-1"><%= number_with_delimiter(@avg_duration) %>ms</p>
+    </div>
+    <div class="bg-white rounded-lg shadow p-4">
+      <p class="text-xs font-semibold text-warm-500 uppercase tracking-wider">Cache Read Tokens</p>
+      <p class="text-2xl font-display font-bold text-green-600 mt-1"><%= number_with_delimiter(@tokens[:cache_read]) %></p>
+    </div>
+    <div class="bg-white rounded-lg shadow p-4">
+      <p class="text-xs font-semibold text-warm-500 uppercase tracking-wider">Errors</p>
+      <p class="text-2xl font-display font-bold <%= @error_count > 0 ? 'text-red-600' : 'text-warm-400' %> mt-1"><%= @error_count %></p>
+    </div>
+  </div>
+
+  <%# Token Usage Summary %>
+  <div class="bg-white rounded-lg shadow p-6 mb-8">
+    <h2 class="text-lg font-display font-bold text-warm-900 mb-4">Token Usage</h2>
+    <div class="grid grid-cols-2 lg:grid-cols-4 gap-6">
+      <div>
+        <p class="text-sm text-warm-500">Input Tokens</p>
+        <p class="text-xl font-bold text-warm-900 tabular-nums"><%= number_with_delimiter(@tokens[:input]) %></p>
+      </div>
+      <div>
+        <p class="text-sm text-warm-500">Output Tokens</p>
+        <p class="text-xl font-bold text-warm-900 tabular-nums"><%= number_with_delimiter(@tokens[:output]) %></p>
+      </div>
+      <div>
+        <p class="text-sm text-warm-500">Cache Creation</p>
+        <p class="text-xl font-bold text-accent-600 tabular-nums"><%= number_with_delimiter(@tokens[:cache_creation]) %></p>
+      </div>
+      <div>
+        <p class="text-sm text-warm-500">Cache Read (saved)</p>
+        <p class="text-xl font-bold text-green-600 tabular-nums"><%= number_with_delimiter(@tokens[:cache_read]) %></p>
+      </div>
+    </div>
+  </div>
+
+  <%# Feature Breakdown %>
+  <% if @feature_breakdown.any? %>
+    <div class="bg-white rounded-lg shadow p-6 mb-8">
+      <h2 class="text-lg font-display font-bold text-warm-900 mb-4">By Feature</h2>
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-warm-200">
+              <th class="text-left py-2 pr-4 text-warm-500 font-semibold">Feature</th>
+              <th class="text-right py-2 px-4 text-warm-500 font-semibold">Requests</th>
+              <th class="text-right py-2 px-4 text-warm-500 font-semibold">Input</th>
+              <th class="text-right py-2 px-4 text-warm-500 font-semibold">Output</th>
+              <th class="text-right py-2 px-4 text-warm-500 font-semibold">Cache Read</th>
+              <th class="text-right py-2 pl-4 text-warm-500 font-semibold">Avg Duration</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @feature_breakdown.each do |row| %>
+              <tr class="border-b border-warm-100">
+                <td class="py-2 pr-4 font-medium text-warm-900"><%= row.feature.titleize %></td>
+                <td class="py-2 px-4 text-right tabular-nums text-warm-700"><%= row.request_count %></td>
+                <td class="py-2 px-4 text-right tabular-nums text-warm-700"><%= number_with_delimiter(row.total_input.to_i) %></td>
+                <td class="py-2 px-4 text-right tabular-nums text-warm-700"><%= number_with_delimiter(row.total_output.to_i) %></td>
+                <td class="py-2 px-4 text-right tabular-nums text-green-600"><%= number_with_delimiter(row.total_cache_read.to_i) %></td>
+                <td class="py-2 pl-4 text-right tabular-nums text-warm-700"><%= row.avg_duration&.round(0) || 0 %>ms</td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  <% end %>
+
+  <%# Recent Requests %>
+  <div class="bg-white rounded-lg shadow p-6">
+    <h2 class="text-lg font-display font-bold text-warm-900 mb-4">Recent Requests</h2>
+    <% if @recent.any? %>
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-warm-200">
+              <th class="text-left py-2 pr-3 text-warm-500 font-semibold">Time</th>
+              <th class="text-left py-2 px-3 text-warm-500 font-semibold">Feature</th>
+              <th class="text-left py-2 px-3 text-warm-500 font-semibold">Model</th>
+              <th class="text-center py-2 px-3 text-warm-500 font-semibold">Cache</th>
+              <th class="text-right py-2 px-3 text-warm-500 font-semibold">Tokens</th>
+              <th class="text-right py-2 pl-3 text-warm-500 font-semibold">Duration</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @recent.each do |metric| %>
+              <tr class="border-b border-warm-100 <%= metric.error_class ? 'bg-red-50' : '' %>">
+                <td class="py-2 pr-3 text-warm-600 whitespace-nowrap"><%= time_ago_in_words(metric.created_at) %> ago</td>
+                <td class="py-2 px-3 font-medium text-warm-900"><%= metric.feature.titleize %></td>
+                <td class="py-2 px-3 text-warm-600 text-xs font-mono"><%= metric.model.split("-").last(2).join("-") %></td>
+                <td class="py-2 px-3 text-center">
+                  <% if metric.cache_hit? %>
+                    <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700">HIT</span>
+                  <% elsif metric.error_class %>
+                    <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-700">ERR</span>
+                  <% else %>
+                    <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-warm-100 text-warm-600">MISS</span>
+                  <% end %>
+                </td>
+                <td class="py-2 px-3 text-right tabular-nums text-warm-700"><%= number_with_delimiter(metric.total_input_tokens + metric.output_tokens) %></td>
+                <td class="py-2 pl-3 text-right tabular-nums text-warm-700"><%= metric.duration_ms&.round(0) || "-" %>ms</td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    <% else %>
+      <p class="text-warm-400 text-center py-8">No AI requests recorded yet.</p>
+    <% end %>
+  </div>
+</div>

--- a/config/initializers/ai_instrumentation.rb
+++ b/config/initializers/ai_instrumentation.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.config.after_initialize do
+  Ai::Instrumentation.subscribe!
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,9 @@ Rails.application.routes.draw do
     # User settings
     resource :settings, only: %i[show update]
 
+    # Admin: AI metrics dashboard
+    resources :ai_metrics, only: :index
+
     # =============================================================================
     # API v1 Routes
     # =============================================================================

--- a/db/migrate/20260302025531_create_ai_request_metrics.rb
+++ b/db/migrate/20260302025531_create_ai_request_metrics.rb
@@ -1,0 +1,25 @@
+class CreateAiRequestMetrics < ActiveRecord::Migration[8.1]
+  def change
+    create_table :ai_request_metrics, id: :string do |t|
+      t.references :account, type: :string, null: true, foreign_key: true
+      t.string :feature, null: false
+      t.string :model, null: false
+      t.string :method_name, null: false
+      t.integer :input_tokens, default: 0
+      t.integer :output_tokens, default: 0
+      t.integer :cache_creation_input_tokens, default: 0
+      t.integer :cache_read_input_tokens, default: 0
+      t.float :duration_ms
+      t.boolean :cache_hit, default: false
+      t.string :error_class
+      t.string :error_message
+
+      t.timestamps
+    end
+
+    add_index :ai_request_metrics, :feature
+    add_index :ai_request_metrics, :created_at
+    add_index :ai_request_metrics, :cache_hit
+    add_index :ai_request_metrics, [ :account_id, :feature, :created_at ], name: "idx_ai_metrics_account_feature_time"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_27_204559) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_02_025531) do
   create_table "access_tokens", id: :string, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "expires_at"
@@ -100,6 +100,28 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_27_204559) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "ai_request_metrics", id: :string, force: :cascade do |t|
+    t.string "account_id"
+    t.integer "cache_creation_input_tokens", default: 0
+    t.boolean "cache_hit", default: false
+    t.integer "cache_read_input_tokens", default: 0
+    t.datetime "created_at", null: false
+    t.float "duration_ms"
+    t.string "error_class"
+    t.string "error_message"
+    t.string "feature", null: false
+    t.integer "input_tokens", default: 0
+    t.string "method_name", null: false
+    t.string "model", null: false
+    t.integer "output_tokens", default: 0
+    t.datetime "updated_at", null: false
+    t.index ["account_id", "feature", "created_at"], name: "idx_ai_metrics_account_feature_time"
+    t.index ["account_id"], name: "index_ai_request_metrics_on_account_id"
+    t.index ["cache_hit"], name: "index_ai_request_metrics_on_cache_hit"
+    t.index ["created_at"], name: "index_ai_request_metrics_on_created_at"
+    t.index ["feature"], name: "index_ai_request_metrics_on_feature"
   end
 
   create_table "ai_task_statuses", id: :string, force: :cascade do |t|
@@ -394,6 +416,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_27_204559) do
   add_foreign_key "account_join_codes", "accounts"
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "ai_request_metrics", "accounts"
   add_foreign_key "ai_task_statuses", "accounts"
   add_foreign_key "dietary_profiles", "accounts"
   add_foreign_key "dietary_profiles", "users"

--- a/test/controllers/accounts/ai_metrics_controller_test.rb
+++ b/test/controllers/accounts/ai_metrics_controller_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+
+class Accounts::AiMetricsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @account = accounts(:one)
+    @owner_session = sessions(:one) # owner user
+  end
+
+  def account_path_prefix
+    "/#{@account.external_account_id}"
+  end
+
+  test "index requires authentication" do
+    get "#{account_path_prefix}/ai_metrics"
+    assert_response :redirect
+  end
+
+  test "index requires admin role" do
+    # Create a session for the member user
+    member_identity = identities(:two)
+    member_session = member_identity.sessions.create!(
+      ip_address: "192.168.1.100",
+      user_agent: "Test Browser",
+      expires_at: 2.weeks.from_now
+    )
+    sign_in_as(member_session)
+
+    get "#{account_path_prefix}/ai_metrics"
+    assert_redirected_to "#{account_path_prefix}/"
+  end
+
+  test "index accessible by owner" do
+    sign_in_as(@owner_session)
+    get "#{account_path_prefix}/ai_metrics"
+    assert_response :success
+    assert_select "h1", "AI Request Metrics"
+  end
+
+  test "index shows summary cards" do
+    sign_in_as(@owner_session)
+    get "#{account_path_prefix}/ai_metrics"
+    assert_response :success
+    assert_select "p", /Total Requests/
+    assert_select "p", /Cache Hit Rate/
+  end
+
+  test "index accepts period parameter" do
+    sign_in_as(@owner_session)
+
+    %w[1h 24h 7d 30d].each do |period|
+      get "#{account_path_prefix}/ai_metrics", params: { period: period }
+      assert_response :success
+    end
+  end
+
+  test "index shows feature breakdown table" do
+    sign_in_as(@owner_session)
+    get "#{account_path_prefix}/ai_metrics", params: { period: "30d" }
+    assert_response :success
+    assert_select "h2", "By Feature"
+  end
+
+  test "index shows recent requests" do
+    sign_in_as(@owner_session)
+    get "#{account_path_prefix}/ai_metrics", params: { period: "30d" }
+    assert_response :success
+    assert_select "h2", "Recent Requests"
+  end
+end

--- a/test/fixtures/ai_request_metrics.yml
+++ b/test/fixtures/ai_request_metrics.yml
@@ -1,0 +1,61 @@
+cache_hit_metric:
+  id: ai_metric_cache_hit
+  account_id: acct_test_one
+  feature: meal_plan_generation
+  model: claude-haiku-4-5-20251001
+  method_name: chat_with_tools
+  input_tokens: 500
+  output_tokens: 200
+  cache_creation_input_tokens: 0
+  cache_read_input_tokens: 1500
+  duration_ms: 1200.5
+  cache_hit: true
+  created_at: <%= 1.hour.ago.iso8601 %>
+  updated_at: <%= 1.hour.ago.iso8601 %>
+
+cache_miss_metric:
+  id: ai_metric_cache_miss
+  account_id: acct_test_one
+  feature: meal_plan_generation
+  model: claude-haiku-4-5-20251001
+  method_name: chat_with_tools
+  input_tokens: 2000
+  output_tokens: 300
+  cache_creation_input_tokens: 1500
+  cache_read_input_tokens: 0
+  duration_ms: 2500.0
+  cache_hit: false
+  created_at: <%= 2.hours.ago.iso8601 %>
+  updated_at: <%= 2.hours.ago.iso8601 %>
+
+recipe_import_metric:
+  id: ai_metric_recipe_import
+  account_id: acct_test_one
+  feature: recipe_import
+  model: claude-sonnet-4-20250514
+  method_name: chat_with_tools
+  input_tokens: 3000
+  output_tokens: 500
+  cache_creation_input_tokens: 0
+  cache_read_input_tokens: 0
+  duration_ms: 3000.0
+  cache_hit: false
+  created_at: <%= 3.hours.ago.iso8601 %>
+  updated_at: <%= 3.hours.ago.iso8601 %>
+
+failed_metric:
+  id: ai_metric_failed
+  account_id: acct_test_one
+  feature: meal_plan_generation
+  model: claude-haiku-4-5-20251001
+  method_name: chat_with_tools
+  input_tokens: 0
+  output_tokens: 0
+  cache_creation_input_tokens: 0
+  cache_read_input_tokens: 0
+  duration_ms: 500.0
+  cache_hit: false
+  error_class: Ai::Client::RateLimitError
+  error_message: Rate limit exceeded
+  created_at: <%= 4.hours.ago.iso8601 %>
+  updated_at: <%= 4.hours.ago.iso8601 %>

--- a/test/models/ai_request_metric_test.rb
+++ b/test/models/ai_request_metric_test.rb
@@ -1,0 +1,106 @@
+require "test_helper"
+
+class AiRequestMetricTest < ActiveSupport::TestCase
+  setup do
+    @account = accounts(:one)
+  end
+
+  test "valid metric" do
+    metric = AiRequestMetric.new(
+      account: @account,
+      feature: "meal_plan_generation",
+      model: "claude-haiku-4-5-20251001",
+      method_name: "chat_with_tools"
+    )
+    assert metric.valid?
+  end
+
+  test "requires feature" do
+    metric = AiRequestMetric.new(feature: nil, model: "test", method_name: "chat")
+    assert_not metric.valid?
+    assert_includes metric.errors[:feature], "can't be blank"
+  end
+
+  test "requires model" do
+    metric = AiRequestMetric.new(feature: "test", model: nil, method_name: "chat")
+    assert_not metric.valid?
+    assert_includes metric.errors[:model], "can't be blank"
+  end
+
+  test "requires method_name" do
+    metric = AiRequestMetric.new(feature: "test", model: "test", method_name: nil)
+    assert_not metric.valid?
+    assert_includes metric.errors[:method_name], "can't be blank"
+  end
+
+  test "account is optional" do
+    metric = AiRequestMetric.new(
+      feature: "test",
+      model: "test",
+      method_name: "chat"
+    )
+    assert metric.valid?
+  end
+
+  test "total_input_tokens sums all input token types" do
+    metric = ai_request_metrics(:cache_hit_metric)
+    assert_equal 500 + 0 + 1500, metric.total_input_tokens
+  end
+
+  test "cache_savings_tokens returns cache_read_input_tokens" do
+    hit = ai_request_metrics(:cache_hit_metric)
+    assert_equal 1500, hit.cache_savings_tokens
+
+    miss = ai_request_metrics(:cache_miss_metric)
+    assert_equal 0, miss.cache_savings_tokens
+  end
+
+  test "estimated_cache_savings_ratio" do
+    hit = ai_request_metrics(:cache_hit_metric)
+    assert_in_delta 0.75, hit.estimated_cache_savings_ratio, 0.01
+
+    miss = ai_request_metrics(:cache_miss_metric)
+    assert_equal 0.0, miss.estimated_cache_savings_ratio
+  end
+
+  test "scopes filter correctly" do
+    assert AiRequestMetric.cache_hits.all?(&:cache_hit?)
+    assert AiRequestMetric.cache_misses.none?(&:cache_hit?)
+    assert AiRequestMetric.successful.none? { |m| m.error_class.present? }
+    assert AiRequestMetric.failed.all? { |m| m.error_class.present? }
+  end
+
+  test "cache_hit_rate class method" do
+    rate = AiRequestMetric.cache_hit_rate(since: 25.hours.ago)
+    # 1 hit out of 3 successful (cache_hit, cache_miss, recipe_import) = 33.3%
+    assert_in_delta 33.3, rate, 0.1
+  end
+
+  test "cache_hit_rate returns 0 with no data" do
+    assert_equal 0.0, AiRequestMetric.cache_hit_rate(since: 1.minute.ago)
+  end
+
+  test "total_tokens_used class method" do
+    tokens = AiRequestMetric.total_tokens_used(since: 25.hours.ago)
+    assert tokens[:input] > 0
+    assert tokens[:output] > 0
+    assert tokens[:cache_read] > 0
+  end
+
+  test "feature_breakdown groups by feature" do
+    breakdown = AiRequestMetric.feature_breakdown(since: 25.hours.ago)
+    features = breakdown.map(&:feature)
+    assert_includes features, "meal_plan_generation"
+    assert_includes features, "recipe_import"
+  end
+
+  test "for_feature scope" do
+    results = AiRequestMetric.for_feature("meal_plan_generation")
+    assert results.all? { |m| m.feature == "meal_plan_generation" }
+  end
+
+  test "since scope" do
+    recent = AiRequestMetric.since(90.minutes.ago)
+    assert recent.all? { |m| m.created_at >= 90.minutes.ago }
+  end
+end

--- a/test/services/ai/instrumentation_test.rb
+++ b/test/services/ai/instrumentation_test.rb
@@ -1,0 +1,121 @@
+require "test_helper"
+
+class Ai::InstrumentationTest < ActiveSupport::TestCase
+  setup do
+    @account = accounts(:one)
+    Current.account = @account
+  end
+
+  teardown do
+    Current.account = nil
+  end
+
+  test "records metric from notification event" do
+    payload = {
+      model: "claude-haiku-4-5-20251001",
+      method_name: "chat_with_tools",
+      feature: "meal_plan_generation",
+      duration_ms: 1500.3,
+      usage: {
+        input_tokens: 500,
+        output_tokens: 200,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 1200
+      },
+      error: nil
+    }
+
+    assert_difference "AiRequestMetric.count" do
+      ActiveSupport::Notifications.instrument("request.ai_client", payload)
+    end
+
+    metric = AiRequestMetric.order(created_at: :desc).first
+    assert_equal @account.id, metric.account_id
+    assert_equal "meal_plan_generation", metric.feature
+    assert_equal "claude-haiku-4-5-20251001", metric.model
+    assert_equal "chat_with_tools", metric.method_name
+    assert_equal 500, metric.input_tokens
+    assert_equal 200, metric.output_tokens
+    assert_equal 0, metric.cache_creation_input_tokens
+    assert_equal 1200, metric.cache_read_input_tokens
+    assert_in_delta 1500.3, metric.duration_ms, 0.1
+    assert metric.cache_hit?
+    assert_nil metric.error_class
+  end
+
+  test "records error details" do
+    error = Ai::Client::RateLimitError.new("Rate limit exceeded")
+    payload = {
+      model: "claude-sonnet-4-20250514",
+      method_name: "chat",
+      feature: "recipe_import",
+      duration_ms: 300.0,
+      usage: {},
+      error: error
+    }
+
+    assert_difference "AiRequestMetric.count" do
+      ActiveSupport::Notifications.instrument("request.ai_client", payload)
+    end
+
+    metric = AiRequestMetric.order(created_at: :desc).first
+    assert_equal "Ai::Client::RateLimitError", metric.error_class
+    assert_equal "Rate limit exceeded", metric.error_message
+    assert_not metric.cache_hit?
+  end
+
+  test "records metric without account context" do
+    Current.account = nil
+
+    payload = {
+      model: "claude-sonnet-4-20250514",
+      method_name: "chat_with_tools",
+      feature: "recipe_import",
+      duration_ms: 2000.0,
+      usage: { input_tokens: 1000, output_tokens: 300, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+      error: nil
+    }
+
+    assert_difference "AiRequestMetric.count" do
+      ActiveSupport::Notifications.instrument("request.ai_client", payload)
+    end
+
+    metric = AiRequestMetric.order(created_at: :desc).first
+    assert_nil metric.account_id
+  end
+
+  test "cache_hit is false when no cache_read_input_tokens" do
+    payload = {
+      model: "claude-haiku-4-5-20251001",
+      method_name: "chat_with_tools",
+      feature: "meal_plan_generation",
+      duration_ms: 2500.0,
+      usage: { input_tokens: 2000, output_tokens: 300, cache_creation_input_tokens: 1500, cache_read_input_tokens: 0 },
+      error: nil
+    }
+
+    ActiveSupport::Notifications.instrument("request.ai_client", payload)
+
+    metric = AiRequestMetric.order(created_at: :desc).first
+    assert_not metric.cache_hit?
+  end
+
+  test "handles empty usage gracefully" do
+    payload = {
+      model: "claude-sonnet-4-20250514",
+      method_name: "chat",
+      feature: "unknown",
+      duration_ms: 100.0,
+      usage: {},
+      error: nil
+    }
+
+    assert_difference "AiRequestMetric.count" do
+      ActiveSupport::Notifications.instrument("request.ai_client", payload)
+    end
+
+    metric = AiRequestMetric.order(created_at: :desc).first
+    assert_equal 0, metric.input_tokens
+    assert_equal 0, metric.output_tokens
+  end
+end

--- a/test/services/recipe_import/ai_extractor_test.rb
+++ b/test/services/recipe_import/ai_extractor_test.rb
@@ -11,7 +11,7 @@ class RecipeImport::AiExtractorTest < ActiveSupport::TestCase
       @tool_input = tool_input
     end
 
-    def chat_with_tools(messages:, tools:, system: nil, max_tokens: 4096)
+    def chat_with_tools(messages:, tools:, system: nil, max_tokens: 4096, feature: nil)
       @last_call = { messages: messages, tools: tools, system: system, max_tokens: max_tokens }
       { name: "extract_recipe", input: @tool_input }
     end

--- a/test/services/recipe_import/ai_generator_test.rb
+++ b/test/services/recipe_import/ai_generator_test.rb
@@ -10,7 +10,7 @@ class RecipeImport::AiGeneratorTest < ActiveSupport::TestCase
       @tool_input = tool_input
     end
 
-    def chat_with_tools(messages:, tools:, system: nil, max_tokens: 4096)
+    def chat_with_tools(messages:, tools:, system: nil, max_tokens: 4096, feature: nil)
       @last_call = { messages: messages, tools: tools, system: system, max_tokens: max_tokens }
       { name: "extract_recipe", input: @tool_input }
     end

--- a/test/services/recipe_import/photo_extractor_test.rb
+++ b/test/services/recipe_import/photo_extractor_test.rb
@@ -11,7 +11,7 @@ class RecipeImport::PhotoExtractorTest < ActiveSupport::TestCase
       @tool_input = tool_input
     end
 
-    def chat_with_tools(messages:, tools:, system: nil, max_tokens: 4096)
+    def chat_with_tools(messages:, tools:, system: nil, max_tokens: 4096, feature: nil)
       @last_call = { messages: messages, tools: tools, system: system, max_tokens: max_tokens }
       { name: "extract_recipe", input: @tool_input }
     end


### PR DESCRIPTION
## Summary

Instruments all AI API calls (meal plan generation, recipe import, photo extraction, quick entry, diet categorization) with per-request metrics tracking. Adds an admin-only dashboard to monitor cache hit rates, token usage, error rates, and per-feature breakdowns.

## Changes

- **AiRequestMetric model** — persists per-request data: tokens (input, output, cache creation, cache read), duration, cache hit flag, errors. Includes scopes and aggregation class methods for dashboard queries.
- **Ai::Client instrumentation** — wraps all API calls (`chat`, `chat_with_tools`, `vision`) with timing and `ActiveSupport::Notifications`. Added `feature:` parameter to all methods for categorization.
- **Ai::Instrumentation subscriber** — listens to `request.ai_client` events, records `AiRequestMetric` entries, logs JSON metrics.
- **AI Metrics dashboard** — admin-only page at `/:account_id/ai_metrics` with period filtering (1h/24h/7d/30d), summary cards, token usage breakdown, feature table, and recent requests list.
- **Bug fix** — Rails enum-generated `admin?` was overriding the custom `User::Role#admin?` that treats owners as admins. Fixed with `define_method` in the `included` block.

## Testing

- 27 new tests (14 model, 5 instrumentation subscriber, 7 controller + 1 existing test fix)
- Updated 3 FakeAiClient test doubles to accept `feature:` keyword
- All 976 tests pass
- Rubocop: no offenses in changed files
- Brakeman: no warnings
- Bundle audit + importmap audit: clean

Closes #63