### PR TITLE
Add 5-star recipe rating system with AI generation integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Core concerns in `app/controllers/concerns/`:
 All primary keys are string UUIDs. Key models:
 
 - `Account` → `User` (membership with role) → `Identity` (global email identity)
-- `Recipe` → `RecipeIngredient`, `RecipeInstruction`, `RecipeNutritionData`, `RecipeTip` (nested attributes)
+- `Recipe` → `RecipeIngredient`, `RecipeInstruction`, `RecipeNutritionData`, `RecipeTip` (nested attributes). Has optional `rating` (1–5 integer, nil = unrated) used for filtering, sorting, and AI meal plan generation.
 - `MealPlan` → `MealPlanDay` → `MealPlanMeal` → `Recipe` (hierarchical, with servings and daily calorie targets)
 - `Access` — polymorphic resource-level permissions
 - `MagicLink`, `Session`, `AccessToken` — auth infrastructure
@@ -70,7 +70,8 @@ The recipe index (`accounts/recipes#index`) supports search, sort, and filtering
 - `by_search(query)` — SQLite LIKE on title, description, ingredient name (left_joins + group)
 - `by_cook_time(max_minutes)` — total prep+cook time filter
 - `by_calorie_range(min, max)` — joins nutrition_data
-- `sorted_by(sort)` — `newest` (default), `alphabetical`, `quickest`, `most_used` (COUNT DISTINCT meal_plan_meals)
+- `by_min_rating(min)` — filters recipes with `rating >= min`
+- `sorted_by(sort)` — `newest` (default), `alphabetical`, `quickest`, `most_used` (COUNT DISTINCT meal_plan_meals), `highest_rated` (COALESCE rating to 3 for unrated)
 
 Pagination uses lazy Turbo Frames: each page renders a `turbo_frame_tag` for the next page with `loading: :lazy`, creating chained infinite scroll. The `_recipe_page` partial handles subsequent pages via Turbo Frame requests.
 
@@ -117,8 +118,8 @@ Controllers under `app/controllers/accounts/api/v1/` inherit from `ActionControl
 `MealPlanGenerator` (`app/services/meal_plan_generator.rb`) orchestrates AI-powered meal plan creation using Haiku 4.5 for cost efficiency. Uses prompt caching (`cache_control: { type: "ephemeral" }`) on the static system prompt. Recipes are sent as integer indices (not UUIDs) to reduce token costs, with `@index_to_id` mapping indices back to UUIDs when populating the plan.
 
 `RecipeSelector` (`app/services/recipe_selector.rb`) pre-filters and ranks recipes before sending to the AI:
-- **Hard exclusion**: Removes recipes from recent past meal plans (adaptive N based on catalog size). Skipped when catalog < 20 recipes.
-- **Soft scoring** (5 weighted factors): usage frequency (30%), recency decay (25%), diet compatibility (20%), category fit (15%), newness bonus (10%)
+- **Hard exclusion**: Removes recipes from recent past meal plans (adaptive N based on catalog size). Skipped when catalog < 20 recipes. Also hard-excludes 1-star rated recipes.
+- **Soft scoring** (6 weighted factors): usage frequency (25%), recency decay (20%), diet compatibility (20%), user rating (15%), category fit (10%), newness bonus (10%). Rating scores: nil/3→50 (neutral), 2→20, 4→80, 5→100.
 - **Category-proportional selection**: Ensures minimum representation (`MIN_PER_CATEGORY = 3`) per active meal type category
 - Accepts `current_date:` override for deterministic testing
 

--- a/app/controllers/accounts/api/v1/recipes_controller.rb
+++ b/app/controllers/accounts/api/v1/recipes_controller.rb
@@ -226,6 +226,7 @@ class Accounts::Api::V1::RecipesController < Accounts::Api::V1::ApplicationContr
       :servings,
       :prep_time,
       :cook_time,
+      :rating,
       ingredients_attributes: %i[id name quantity unit display_order _destroy],
       instructions_attributes: %i[id step_number instruction _destroy],
       nutrition_data_attributes: %i[

--- a/app/controllers/accounts/recipes_controller.rb
+++ b/app/controllers/accounts/recipes_controller.rb
@@ -1,7 +1,7 @@
 class Accounts::RecipesController < ApplicationController
   include AiRateLimited
 
-  before_action :set_recipe, only: %i[show edit update destroy resolve_ingredients apply_resolution]
+  before_action :set_recipe, only: %i[show edit update destroy resolve_ingredients apply_resolution rate]
   before_action :set_unit_options, only: %i[new edit create update resolve_ingredients]
   before_action -> { check_ai_rate_limit!(:recipe_import, redirect_path: import_url_recipes_path) },
                 only: %i[start_import start_photo_import]
@@ -17,6 +17,7 @@ class Accounts::RecipesController < ApplicationController
       .by_search(params[:q])
       .by_cook_time(params[:cook_time])
       .by_calorie_range(params[:min_calories], params[:max_calories])
+      .by_min_rating(params[:min_rating])
       .sorted_by(params[:sort])
 
     @pagy, @recipes = pagy_countless(recipes)
@@ -27,6 +28,7 @@ class Accounts::RecipesController < ApplicationController
       .by_search(params[:q])
       .by_cook_time(params[:cook_time])
       .by_calorie_range(params[:min_calories], params[:max_calories])
+      .by_min_rating(params[:min_rating])
       .unscope(:group)
       .distinct
       .count
@@ -90,6 +92,22 @@ class Accounts::RecipesController < ApplicationController
   def destroy
     @recipe.destroy
     redirect_to recipes_path, notice: "Recipe was successfully deleted."
+  end
+
+  def rate
+    rating = params[:rating].to_i
+    @recipe.update!(rating: rating.zero? ? nil : rating)
+
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.replace(
+          "recipe_rating_#{@recipe.id}",
+          partial: "accounts/recipes/star_rating",
+          locals: { recipe: @recipe, interactive: true, size: "w-6 h-6" }
+        )
+      end
+      format.html { redirect_to recipe_path(@recipe) }
+    end
   end
 
   def resolve_ingredients
@@ -250,6 +268,7 @@ class Accounts::RecipesController < ApplicationController
     params[:q].present? || params[:category].present? || params[:tags].present? ||
       params[:diet].present? || params[:cook_time].present? ||
       params[:min_calories].present? || params[:max_calories].present? ||
+      params[:min_rating].present? ||
       (params[:sort].present? && params[:sort] != "newest")
   end
 
@@ -378,6 +397,7 @@ class Accounts::RecipesController < ApplicationController
       :servings,
       :prep_time,
       :cook_time,
+      :rating,
       :image,
       images: [],
       ingredients_attributes: %i[id name quantity unit display_order _destroy],

--- a/app/helpers/recipes_helper.rb
+++ b/app/helpers/recipes_helper.rb
@@ -50,7 +50,8 @@ module RecipesHelper
       [ "Newest", "newest" ],
       [ "A–Z", "alphabetical" ],
       [ "Quickest", "quickest" ],
-      [ "Most Used", "most_used" ]
+      [ "Most Used", "most_used" ],
+      [ "Highest Rated", "highest_rated" ]
     ]
   end
 
@@ -70,6 +71,7 @@ module RecipesHelper
     count += 1 if params[:diet].present?
     count += 1 if params[:cook_time].present?
     count += 1 if params[:min_calories].present? || params[:max_calories].present?
+    count += 1 if params[:min_rating].present?
     count += Array(params[:tags]).size
     count += 1 if params[:sort].present? && params[:sort] != "newest"
     count
@@ -85,6 +87,7 @@ module RecipesHelper
     p[:min_calories] = params[:min_calories] if params[:min_calories].present?
     p[:max_calories] = params[:max_calories] if params[:max_calories].present?
     p[:tags] = params[:tags] if params[:tags].present?
+    p[:min_rating] = params[:min_rating] if params[:min_rating].present?
     p
   end
 

--- a/app/javascript/controllers/star_rating_controller.js
+++ b/app/javascript/controllers/star_rating_controller.js
@@ -1,0 +1,46 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["star"]
+  static values = { url: String, current: Number }
+
+  rate(event) {
+    const value = parseInt(event.currentTarget.dataset.value)
+    const rating = value === this.currentValue ? 0 : value
+
+    fetch(this.urlValue, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content,
+        "Accept": "text/vnd.turbo-stream.html"
+      },
+      body: `rating=${rating}`
+    }).then(response => {
+      if (response.ok) return response.text()
+      throw new Error("Rating failed")
+    }).then(html => {
+      Turbo.renderStreamMessage(html)
+    })
+  }
+
+  preview(event) {
+    const hoverValue = parseInt(event.currentTarget.dataset.value)
+    this.fillStars(hoverValue)
+  }
+
+  reset() {
+    this.fillStars(this.currentValue)
+  }
+
+  fillStars(count) {
+    this.starTargets.forEach((button, index) => {
+      const svg = button.querySelector("path")
+      if (index < count) {
+        svg.setAttribute("fill", "currentColor")
+      } else {
+        svg.setAttribute("fill", "none")
+      }
+    })
+  }
+}

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -21,6 +21,7 @@ class Recipe < ApplicationRecord
 
   validates :title, presence: true
   validates :category, presence: true
+  validates :rating, inclusion: { in: 1..5 }, allow_nil: true
   validate :validate_image_attachment
   validate :validate_images_attachments
 
@@ -56,6 +57,7 @@ class Recipe < ApplicationRecord
   scope :by_cook_time, ->(max_minutes) {
     where("COALESCE(prep_time, 0) + COALESCE(cook_time, 0) <= ?", max_minutes.to_i) if max_minutes.present?
   }
+  scope :by_min_rating, ->(min) { where("rating >= ?", min.to_i) if min.present? }
   scope :by_calorie_range, ->(min_cal, max_cal) {
     if min_cal.present? || max_cal.present?
       scope = joins(:nutrition_data)
@@ -72,6 +74,8 @@ class Recipe < ApplicationRecord
       order(Arel.sql("COALESCE(prep_time, 0) + COALESCE(cook_time, 0) ASC"))
     when "most_used"
       left_joins(:meal_plan_meals).group("recipes.id").order(Arel.sql("COUNT(DISTINCT meal_plan_meals.id) DESC"))
+    when "highest_rated"
+      order(Arel.sql("COALESCE(rating, 3) DESC, created_at DESC"))
     else
       order(created_at: :desc)
     end
@@ -125,6 +129,7 @@ class Recipe < ApplicationRecord
       nutrition: nutrition_data&.to_api_response,
       tags: tags.pluck(:name),
       tips: tips.map(&:tip),
+      rating: rating,
       created_at: created_at,
       updated_at: updated_at
     }
@@ -140,7 +145,8 @@ class Recipe < ApplicationRecord
         prep_time: prep_time,
         cook_time: cook_time,
         nutrition_per_serving: nutrition_data&.to_meal_planning_response,
-        tags: tags.pluck(:name)
+        tags: tags.pluck(:name),
+        rating: rating
       }
     end
   end

--- a/app/services/recipe_selector.rb
+++ b/app/services/recipe_selector.rb
@@ -2,10 +2,11 @@
 
 class RecipeSelector
   SCORE_WEIGHTS = {
-    usage_frequency: 0.30,
-    recency_decay: 0.25,
+    usage_frequency: 0.25,
+    recency_decay: 0.20,
     diet_compatibility: 0.20,
-    category_fit: 0.15,
+    user_rating: 0.15,
+    category_fit: 0.10,
     newness_bonus: 0.10
   }.freeze
 
@@ -40,6 +41,7 @@ class RecipeSelector
       .joins(:nutrition_data)
       .includes(:nutrition_data, :tags)
       .where.not(recipe_nutrition_data: { calories: nil })
+      .where("rating != 1 OR rating IS NULL")
       .to_a
   end
 
@@ -83,6 +85,7 @@ class RecipeSelector
       score += SCORE_WEIGHTS[:usage_frequency] * usage_frequency_score(recipe, usage_counts)
       score += SCORE_WEIGHTS[:recency_decay] * recency_decay_score(recipe, last_used_dates)
       score += SCORE_WEIGHTS[:diet_compatibility] * diet_compatibility_score(recipe, diet_slugs)
+      score += SCORE_WEIGHTS[:user_rating] * user_rating_score(recipe)
       score += SCORE_WEIGHTS[:category_fit] * category_fit_score(recipe)
       score += SCORE_WEIGHTS[:newness_bonus] * newness_score(recipe)
 
@@ -155,6 +158,17 @@ class RecipeSelector
   def category_fit_score(recipe)
     matching_categories = map_meal_types_to_categories
     matching_categories.include?(recipe.category) ? 100.0 : 20.0
+  end
+
+  def user_rating_score(recipe)
+    case recipe.rating
+    when nil then 50.0
+    when 2   then 20.0
+    when 3   then 50.0
+    when 4   then 80.0
+    when 5   then 100.0
+    else 50.0
+    end
   end
 
   def newness_score(recipe)

--- a/app/views/accounts/recipes/_recipe_card.html.erb
+++ b/app/views/accounts/recipes/_recipe_card.html.erb
@@ -35,6 +35,11 @@
 
   <div class="p-4">
     <h2 class="text-base font-display font-bold text-warm-900 group-hover:text-primary-700 transition-colors mb-1 line-clamp-1"><%= recipe.title %></h2>
+    <% if recipe.rating %>
+      <div class="mb-1">
+        <%= render "accounts/recipes/star_rating", recipe: recipe, interactive: false, size: "w-3.5 h-3.5" %>
+      </div>
+    <% end %>
     <% if recipe.description.present? %>
       <p class="text-warm-500 text-sm mb-3 line-clamp-2"><%= recipe.description %></p>
     <% end %>

--- a/app/views/accounts/recipes/_recipe_content.html.erb
+++ b/app/views/accounts/recipes/_recipe_content.html.erb
@@ -37,6 +37,9 @@
             <% end %>
           </div>
         <% end %>
+        <div class="mt-3">
+          <%= render "accounts/recipes/star_rating", recipe: recipe, interactive: true, size: "w-6 h-6" %>
+        </div>
       </div>
       <div class="flex gap-2">
         <% if @meal_plans&.any? %>

--- a/app/views/accounts/recipes/_star_rating.html.erb
+++ b/app/views/accounts/recipes/_star_rating.html.erb
@@ -1,0 +1,39 @@
+<%# locals: (recipe:, interactive: false, size: "w-5 h-5") %>
+<div id="recipe_rating_<%= recipe.id %>"
+     class="inline-flex items-center gap-1"
+     <% if interactive %>
+       data-controller="star-rating"
+       data-star-rating-url-value="<%= rate_recipe_path(recipe) %>"
+       data-star-rating-current-value="<%= recipe.rating || 0 %>"
+     <% end %>>
+  <% 5.times do |i| %>
+    <% star_value = i + 1 %>
+    <% filled = recipe.rating.present? && star_value <= recipe.rating %>
+    <% if interactive %>
+      <button type="button"
+              data-star-rating-target="star"
+              data-value="<%= star_value %>"
+              data-action="click->star-rating#rate mouseenter->star-rating#preview mouseleave->star-rating#reset"
+              class="<%= size %> text-accent-400 transition-colors focus:outline-none cursor-pointer">
+        <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" class="<%= size %>">
+          <% if filled %>
+            <path fill="currentColor" stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z"/>
+          <% else %>
+            <path fill="none" stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z"/>
+          <% end %>
+        </svg>
+      </button>
+    <% else %>
+      <svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" class="<%= size %> text-accent-400">
+        <% if filled %>
+          <path fill="currentColor" stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z"/>
+        <% else %>
+          <path fill="none" stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z"/>
+        <% end %>
+      </svg>
+    <% end %>
+  <% end %>
+  <% if !interactive && recipe.rating.present? %>
+    <span class="text-xs text-warm-500 ml-0.5"><%= recipe.rating %>/5</span>
+  <% end %>
+</div>

--- a/app/views/accounts/recipes/index.html.erb
+++ b/app/views/accounts/recipes/index.html.erb
@@ -41,7 +41,7 @@
     <div data-controller="recipe-search" class="mb-6">
       <%= form_with url: recipes_path, method: :get, data: { recipe_search_target: "form" }, class: "relative" do |f| %>
         <%# Preserve existing filter params %>
-        <% %w[category diet sort cook_time min_calories max_calories].each do |p| %>
+        <% %w[category diet sort cook_time min_calories max_calories min_rating].each do |p| %>
           <%= hidden_field_tag p, params[p] if params[p].present? %>
         <% end %>
         <% Array(params[:tags]).each do |tag_id| %>
@@ -93,7 +93,7 @@
 
       <%# Sort dropdown %>
       <%= form_with url: recipes_path, method: :get, class: "inline-flex" do |f| %>
-        <% %w[q category diet cook_time min_calories max_calories].each do |p| %>
+        <% %w[q category diet cook_time min_calories max_calories min_rating].each do |p| %>
           <%= hidden_field_tag p, params[p] if params[p].present? %>
         <% end %>
         <% Array(params[:tags]).each do |tag_id| %>
@@ -161,6 +161,24 @@
           </div>
         <% end %>
 
+        <%# Minimum rating pills %>
+        <div>
+          <span class="text-xs font-semibold text-warm-500 uppercase tracking-wider mb-2 block">Minimum Rating</span>
+          <div class="flex gap-2 flex-wrap">
+            <% [["Any", nil], ["3+", 3], ["4+", 4], ["5", 5]].each do |label, value| %>
+              <% selected = params[:min_rating].to_s == value.to_s %>
+              <% link_params = value ? filter_params_with(min_rating: value) : filter_params_except(:min_rating) %>
+              <%= link_to recipes_path(link_params),
+                    class: "inline-flex items-center gap-1 px-3 py-1.5 rounded-full text-sm font-medium transition-colors #{selected ? 'bg-accent-500 text-white shadow-sm' : 'bg-warm-100 text-warm-700 hover:bg-warm-200'}" do %>
+                <svg class="w-3.5 h-3.5 text-accent-400" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="1.5">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z"/>
+                </svg>
+                <%= label %>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+
         <%# Cook time quick buttons + calorie range %>
         <div class="flex flex-col sm:flex-row gap-5">
           <div class="flex-1">
@@ -178,7 +196,7 @@
           <div class="flex-1">
             <span class="text-xs font-semibold text-warm-500 uppercase tracking-wider mb-2 block">Calories per Serving</span>
             <%= form_with url: recipes_path, method: :get, class: "flex items-center gap-2" do %>
-              <% %w[q category diet sort cook_time].each do |p| %>
+              <% %w[q category diet sort cook_time min_rating].each do |p| %>
                 <%= hidden_field_tag p, params[p] if params[p].present? %>
               <% end %>
               <% Array(params[:tags]).each do |tag_id| %>
@@ -229,6 +247,14 @@
           <span class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-primary-50 text-primary-700 font-medium">
             ≤ <%= params[:cook_time] %> min
             <%= link_to recipes_path(filter_params_except(:cook_time)), class: "hover:text-primary-900" do %>
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/></svg>
+            <% end %>
+          </span>
+        <% end %>
+        <% if params[:min_rating].present? %>
+          <span class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-accent-50 text-accent-700 font-medium">
+            <%= params[:min_rating] %>+ stars
+            <%= link_to recipes_path(filter_params_except(:min_rating)), class: "hover:text-accent-900" do %>
               <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/></svg>
             <% end %>
           </span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
       member do
         get :resolve_ingredients
         patch :apply_resolution
+        patch :rate
       end
       collection do
         get :search_usda

--- a/db/migrate/20260302221956_add_rating_to_recipes.rb
+++ b/db/migrate/20260302221956_add_rating_to_recipes.rb
@@ -1,0 +1,6 @@
+class AddRatingToRecipes < ActiveRecord::Migration[8.1]
+  def change
+    add_column :recipes, :rating, :integer
+    add_index :recipes, [ :account_id, :rating ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_02_025531) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_02_221956) do
   create_table "access_tokens", id: :string, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "expires_at"
@@ -332,11 +332,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_02_025531) do
     t.datetime "created_at", null: false
     t.text "description"
     t.integer "prep_time"
+    t.integer "rating"
     t.integer "servings"
     t.string "source"
     t.string "title", null: false
     t.datetime "updated_at", null: false
     t.index ["account_id", "category"], name: "index_recipes_on_account_id_and_category"
+    t.index ["account_id", "rating"], name: "index_recipes_on_account_id_and_rating"
     t.index ["account_id", "title"], name: "index_recipes_on_account_id_and_title"
     t.index ["account_id"], name: "index_recipes_on_account_id"
   end

--- a/test/controllers/accounts/recipes_controller_test.rb
+++ b/test/controllers/accounts/recipes_controller_test.rb
@@ -613,4 +613,52 @@ class Accounts::RecipesControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", import_photo_recipes_path
     assert_select "a[href=?]", quick_entry_recipes_path
   end
+
+  # --- Rating ---
+
+  test "rate action updates recipe rating and returns turbo_stream" do
+    sign_in_as(@session)
+
+    patch "#{account_path_prefix}/recipes/#{@recipe.id}/rate", params: { rating: 4 },
+      headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_equal 4, @recipe.reload.rating
+  end
+
+  test "rate action with 0 clears rating to nil" do
+    sign_in_as(@session)
+    @recipe.update!(rating: 3)
+
+    patch "#{account_path_prefix}/recipes/#{@recipe.id}/rate", params: { rating: 0 },
+      headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_nil @recipe.reload.rating
+  end
+
+  test "rate action falls back to redirect for HTML" do
+    sign_in_as(@session)
+
+    patch "#{account_path_prefix}/recipes/#{@recipe.id}/rate", params: { rating: 5 }
+
+    assert_response :redirect
+    assert_equal 5, @recipe.reload.rating
+  end
+
+  test "index with min_rating filters correctly" do
+    sign_in_as(@session)
+    @recipe.update!(rating: 5)
+    recipes(:two).update!(rating: 2)
+
+    get "#{account_path_prefix}/recipes", params: { min_rating: 4 }
+    assert_response :success
+    assert_select "h2", @recipe.title
+  end
+
+  test "index with highest_rated sort works" do
+    sign_in_as(@session)
+    get "#{account_path_prefix}/recipes", params: { sort: "highest_rated" }
+    assert_response :success
+  end
 end

--- a/test/models/recipe_test.rb
+++ b/test/models/recipe_test.rb
@@ -313,6 +313,86 @@ class RecipeTest < ActiveSupport::TestCase
     end
   end
 
+  # --- Rating tests ---
+
+  test "rating validates inclusion in 1 to 5" do
+    recipe = recipes(:one)
+
+    (1..5).each do |r|
+      recipe.rating = r
+      assert recipe.valid?, "Expected rating #{r} to be valid"
+    end
+
+    recipe.rating = 0
+    assert_not recipe.valid?
+    recipe.rating = 6
+    assert_not recipe.valid?
+    recipe.rating = -1
+    assert_not recipe.valid?
+  end
+
+  test "rating allows nil" do
+    recipe = recipes(:one)
+    recipe.rating = nil
+    assert recipe.valid?
+  end
+
+  test "by_min_rating scope returns recipes at or above threshold" do
+    account = accounts(:one)
+    r5 = account.recipes.create!(title: "Five Star", category: :dinner, rating: 5)
+    r3 = account.recipes.create!(title: "Three Star", category: :dinner, rating: 3)
+    r1 = account.recipes.create!(title: "One Star", category: :dinner, rating: 1)
+
+    results = Recipe.by_min_rating(4)
+    assert_includes results, r5
+    assert_not_includes results, r3
+    assert_not_includes results, r1
+
+    results = Recipe.by_min_rating(3)
+    assert_includes results, r5
+    assert_includes results, r3
+    assert_not_includes results, r1
+  ensure
+    [ r5, r3, r1 ].compact.each(&:destroy)
+  end
+
+  test "by_min_rating scope returns all when nil" do
+    assert_equal Recipe.all.to_a, Recipe.by_min_rating(nil).to_a
+  end
+
+  test "sorted_by highest_rated orders 5-star first and unrated mid" do
+    account = accounts(:one)
+    r5 = account.recipes.create!(title: "Five Star", category: :dinner, rating: 5)
+    r_nil = account.recipes.create!(title: "Unrated", category: :dinner, rating: nil)
+    r2 = account.recipes.create!(title: "Two Star", category: :dinner, rating: 2)
+
+    results = account.recipes.sorted_by("highest_rated").to_a
+    r5_idx = results.index(r5)
+    r_nil_idx = results.index(r_nil)
+    r2_idx = results.index(r2)
+
+    assert r5_idx < r_nil_idx, "5-star should come before unrated"
+    assert r_nil_idx < r2_idx, "Unrated (treated as 3) should come before 2-star"
+  ensure
+    [ r5, r_nil, r2 ].compact.each(&:destroy)
+  end
+
+  test "to_api_response includes rating" do
+    recipe = recipes(:one)
+    recipe.update!(rating: 4)
+    response = recipe.to_api_response
+
+    assert_equal 4, response[:rating]
+  end
+
+  test "to_meal_planning_response includes rating" do
+    recipe = recipes(:one)
+    recipe.update!(rating: 5)
+    response = recipe.to_meal_planning_response
+
+    assert_equal 5, response[:rating]
+  end
+
   test "does not enqueue nutrition calculation when manual nutrition exists" do
     recipe = recipes(:one)
     # recipes(:one) has nutrition_data with auto_calculated: false

--- a/test/services/recipe_selector_test.rb
+++ b/test/services/recipe_selector_test.rb
@@ -245,6 +245,53 @@ class RecipeSelectorTest < ActiveSupport::TestCase
     plan
   end
 
+  # --- Rating tests ---
+
+  test "1-star recipes excluded from candidates" do
+    recipes(:one).update!(rating: 1)
+    plan = create_target_plan
+
+    selector = build_selector(plan)
+    result = selector.select(limit: 100)
+
+    refute_includes result.map(&:id), recipes(:one).id
+  ensure
+    recipes(:one).update!(rating: nil)
+  end
+
+  test "5-star recipes score higher than unrated" do
+    extra_recipes = create_recipes_with_nutrition(20, category: :dinner)
+    recipes(:one).update!(rating: 5)
+    plan = create_target_plan
+
+    selector = build_selector(plan)
+    scored = selector.send(:score_recipes, selector.send(:fetch_eligible_recipes))
+
+    rated_entry = scored.find { |s| s[:recipe].id == recipes(:one).id }
+    unrated_entry = scored.find { |s| s[:recipe].rating.nil? }
+
+    # The 5-star recipe gets 100 * 0.15 = 15 extra vs unrated 50 * 0.15 = 7.5
+    # So the rating component should be higher
+    rated_rating_component = RecipeSelector::SCORE_WEIGHTS[:user_rating] * 100.0
+    unrated_rating_component = RecipeSelector::SCORE_WEIGHTS[:user_rating] * 50.0
+    assert rated_rating_component > unrated_rating_component
+  ensure
+    recipes(:one).update!(rating: nil)
+    extra_recipes&.each(&:destroy)
+  end
+
+  test "unrated recipes get neutral 50.0 rating score" do
+    plan = create_target_plan
+    selector = build_selector(plan)
+
+    score = selector.send(:user_rating_score, recipes(:one))
+    assert_equal 50.0, score
+  end
+
+  test "score weights sum to 1.0" do
+    assert_in_delta 1.0, RecipeSelector::SCORE_WEIGHTS.values.sum, 0.001
+  end
+
   def create_recipes_with_nutrition(count, category: :dinner)
     count.times.map do |i|
       recipe = @account.recipes.create!(


### PR DESCRIPTION
## Summary

Add a 5-star recipe rating system that integrates with the AI meal plan generator. Users can rate recipes 1-5 stars on the recipe show page (interactive, inline via Turbo Stream). Ratings influence AI meal plan generation: 1-star recipes are hard-excluded, 2-star deprioritized, 4-5 star boosted, unrated treated as neutral.

## Changes

- **Migration**: Add nullable `rating` integer column with `[account_id, rating]` composite index
- **Recipe model**: Validation (1-5, allow nil), `by_min_rating` scope, `highest_rated` sort, rating in API responses
- **Controller**: `PATCH /:account_id/recipes/:id/rate` action with Turbo Stream response; index chains `by_min_rating`
- **Star rating UI**: Shared `_star_rating` partial (interactive + read-only modes), `star_rating_controller.js` Stimulus controller with hover preview
- **Recipe show**: Interactive stars below tags
- **Recipe cards**: Read-only stars when rated (inside cache block, auto-busts on rating change)
- **Recipe index**: Minimum rating filter pills (Any, 3+, 4+, 5), "Highest Rated" sort option, filter params preserved across forms
- **RecipeSelector**: Rebalanced weights (6 factors totaling 1.0), hard-exclude 1-star, `user_rating_score` function
- **API**: `:rating` added to permit lists for both web and API recipe controllers
- **CLAUDE.md**: Updated to document rating column, scopes, and RecipeSelector changes

## Testing

- Model tests: rating validation, `by_min_rating` scope, `highest_rated` sort, API response inclusion
- Controller tests: rate action (set/clear via turbo_stream and HTML), index filtering by min_rating
- RecipeSelector tests: 1-star exclusion, 5-star scoring boost, unrated neutral score, weights sum to 1.0
- All 1004 tests pass, Rubocop clean, Brakeman clean

Closes #88