### PR TITLE
Extract shared normalize method and duplicated code across services and controllers

### DIFF
--- a/app/controllers/accounts/api/v1/meal_plans_controller.rb
+++ b/app/controllers/accounts/api/v1/meal_plans_controller.rb
@@ -1,5 +1,6 @@
 class Accounts::Api::V1::MealPlansController < Accounts::Api::V1::ApplicationController
   include AiRateLimited
+  include MealPlanSetupable
 
   before_action :require_write_permission!, only: %i[create update destroy generate swap_meal regenerate_day]
   before_action :set_meal_plan, only: %i[show update destroy swap_meal regenerate_day]
@@ -171,23 +172,6 @@ class Accounts::Api::V1::MealPlansController < Accounts::Api::V1::ApplicationCon
     @task = current_account.ai_task_statuses.find(params[:task_id])
   rescue ActiveRecord::RecordNotFound
     render json: { error: "Task not found" }, status: :not_found
-  end
-
-  def generate_days(plan)
-    (plan.start_date..plan.end_date).each_with_index do |date, index|
-      plan.days.create!(date: date, day_number: index + 1)
-    end
-  end
-
-  def attach_participants(plan, profile_ids)
-    return unless profile_ids.present?
-
-    Array(profile_ids).reject(&:blank?).each do |profile_id|
-      profile = current_account.dietary_profiles.active.find_by(id: profile_id)
-      next unless profile
-
-      plan.participants.create!(dietary_profile: profile)
-    end
   end
 
   def recalculate_portions_for(meal)

--- a/app/controllers/accounts/api/v1/recipes_controller.rb
+++ b/app/controllers/accounts/api/v1/recipes_controller.rb
@@ -1,5 +1,6 @@
 class Accounts::Api::V1::RecipesController < Accounts::Api::V1::ApplicationController
   include AiRateLimited
+  include RecipeParamsPermittable
 
   before_action :require_write_permission!, only: %i[create update destroy import_url import_photo import_confirm calculate_nutrition]
   before_action :set_recipe, only: %i[show update destroy calculate_nutrition]
@@ -218,22 +219,6 @@ class Accounts::Api::V1::RecipesController < Accounts::Api::V1::ApplicationContr
   end
 
   def recipe_params
-    params.require(:recipe).permit(
-      :title,
-      :description,
-      :category,
-      :source,
-      :servings,
-      :prep_time,
-      :cook_time,
-      :rating,
-      ingredients_attributes: %i[id name quantity unit display_order _destroy],
-      instructions_attributes: %i[id step_number instruction _destroy],
-      nutrition_data_attributes: %i[
-        id calories fat protein carbs fiber
-        sodium potassium magnesium _destroy
-      ],
-      tips_attributes: %i[id tip _destroy]
-    )
+    permitted_recipe_params
   end
 end

--- a/app/controllers/accounts/meal_plans_controller.rb
+++ b/app/controllers/accounts/meal_plans_controller.rb
@@ -1,5 +1,6 @@
 class Accounts::MealPlansController < ApplicationController
   include AiRateLimited
+  include MealPlanSetupable
 
   before_action :set_meal_plan, only: %i[show edit update destroy duplicate regenerate_day]
   before_action -> { check_ai_rate_limit!(:meal_plan_generation, redirect_path: new_meal_plan_path) },
@@ -164,23 +165,6 @@ class Accounts::MealPlansController < ApplicationController
 
   def meal_plan_params
     params.require(:meal_plan).permit(:name, :start_date, :end_date, :daily_calories_target)
-  end
-
-  def generate_days(plan)
-    (plan.start_date..plan.end_date).each_with_index do |date, index|
-      plan.days.create!(date: date, day_number: index + 1)
-    end
-  end
-
-  def attach_participants(plan, profile_ids)
-    return unless profile_ids.present?
-
-    Array(profile_ids).reject(&:blank?).each do |profile_id|
-      profile = Current.account.dietary_profiles.active.find_by(id: profile_id)
-      next unless profile
-
-      plan.participants.create!(dietary_profile: profile)
-    end
   end
 
   def sync_days(plan, old_start, old_end)

--- a/app/controllers/accounts/recipes_controller.rb
+++ b/app/controllers/accounts/recipes_controller.rb
@@ -1,5 +1,6 @@
 class Accounts::RecipesController < ApplicationController
   include AiRateLimited
+  include RecipeParamsPermittable
 
   before_action :set_recipe, only: %i[show edit update destroy resolve_ingredients apply_resolution rate]
   before_action :set_unit_options, only: %i[new edit create update resolve_ingredients]
@@ -389,24 +390,6 @@ class Accounts::RecipesController < ApplicationController
   end
 
   def recipe_params
-    params.require(:recipe).permit(
-      :title,
-      :description,
-      :category,
-      :source,
-      :servings,
-      :prep_time,
-      :cook_time,
-      :rating,
-      :image,
-      images: [],
-      ingredients_attributes: %i[id name quantity unit display_order _destroy],
-      instructions_attributes: %i[id step_number instruction _destroy],
-      nutrition_data_attributes: %i[
-        id calories fat protein carbs fiber
-        sodium potassium magnesium _destroy
-      ],
-      tips_attributes: %i[id tip _destroy]
-    )
+    permitted_recipe_params(:image, images: [])
   end
 end

--- a/app/controllers/concerns/meal_plan_setupable.rb
+++ b/app/controllers/concerns/meal_plan_setupable.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module MealPlanSetupable
+  extend ActiveSupport::Concern
+
+  private
+
+  def generate_days(plan)
+    (plan.start_date..plan.end_date).each_with_index do |date, index|
+      plan.days.create!(date: date, day_number: index + 1)
+    end
+  end
+
+  def attach_participants(plan, profile_ids)
+    return unless profile_ids.present?
+
+    Array(profile_ids).reject(&:blank?).each do |profile_id|
+      profile = Current.account.dietary_profiles.active.find_by(id: profile_id)
+      next unless profile
+
+      plan.participants.create!(dietary_profile: profile)
+    end
+  end
+end

--- a/app/controllers/concerns/recipe_params_permittable.rb
+++ b/app/controllers/concerns/recipe_params_permittable.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module RecipeParamsPermittable
+  extend ActiveSupport::Concern
+
+  PERMITTED_RECIPE_PARAMS = [
+    :title,
+    :description,
+    :category,
+    :source,
+    :servings,
+    :prep_time,
+    :cook_time,
+    :rating,
+    { ingredients_attributes: %i[id name quantity unit display_order _destroy],
+      instructions_attributes: %i[id step_number instruction _destroy],
+      nutrition_data_attributes: %i[
+        id calories fat protein carbs fiber
+        sodium potassium magnesium _destroy
+      ],
+      tips_attributes: %i[id tip _destroy] }
+  ].freeze
+
+  private
+
+  def permitted_recipe_params(*extra)
+    params.require(:recipe).permit(*PERMITTED_RECIPE_PARAMS, *extra)
+  end
+end

--- a/app/services/recipe_import/ai_extractor.rb
+++ b/app/services/recipe_import/ai_extractor.rb
@@ -2,6 +2,8 @@
 
 module RecipeImport
   class AiExtractor
+    include RecipeImport::Normalizer
+
     SYSTEM_PROMPT = <<~PROMPT
       You are a recipe extraction assistant. Given the text content of a web page,
       extract the recipe information and return it using the provided tool.
@@ -59,33 +61,6 @@ module RecipeImport
       )
 
       normalize(result[:input])
-    end
-
-    private
-
-    def normalize(input)
-      instructions = (input["instructions"] || []).map.with_index(1) do |text, i|
-        { step_number: i, instruction: text }
-      end
-
-      nutrition = {
-        calories: input["calories"],
-        fat: input["fat"],
-        protein: input["protein"],
-        carbs: input["carbs"],
-        fiber: input["fiber"]
-      }.compact.presence
-
-      {
-        title: input["title"],
-        description: input["description"],
-        servings: input["servings"],
-        prep_time: input["prep_time"],
-        cook_time: input["cook_time"],
-        ingredients: input["ingredients"] || [],
-        instructions: instructions,
-        nutrition: nutrition
-      }.compact
     end
   end
 end

--- a/app/services/recipe_import/normalizer.rb
+++ b/app/services/recipe_import/normalizer.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module RecipeImport
+  module Normalizer
+    def normalize(input)
+      instructions = (input["instructions"] || []).map.with_index(1) do |text, i|
+        { step_number: i, instruction: text }
+      end
+
+      nutrition = {
+        calories: input["calories"],
+        fat: input["fat"],
+        protein: input["protein"],
+        carbs: input["carbs"],
+        fiber: input["fiber"]
+      }.compact.presence
+
+      {
+        title: input["title"],
+        description: input["description"],
+        servings: input["servings"],
+        prep_time: input["prep_time"],
+        cook_time: input["cook_time"],
+        ingredients: input["ingredients"] || [],
+        instructions: instructions,
+        nutrition: nutrition
+      }.compact
+    end
+  end
+end

--- a/app/services/recipe_import/photo_extractor.rb
+++ b/app/services/recipe_import/photo_extractor.rb
@@ -2,6 +2,8 @@
 
 module RecipeImport
   class PhotoExtractor
+    include RecipeImport::Normalizer
+
     SYSTEM_PROMPT = <<~PROMPT
       You are a recipe extraction assistant. Given one or more photos of a recipe
       (cookbook page, handwritten card, screenshot, etc.), extract the recipe information
@@ -75,31 +77,6 @@ module RecipeImport
 
     def valid_blob?(blob)
       SUPPORTED_CONTENT_TYPES.include?(blob.content_type) && blob.byte_size <= MAX_IMAGE_SIZE
-    end
-
-    def normalize(input)
-      instructions = (input["instructions"] || []).map.with_index(1) do |text, i|
-        { step_number: i, instruction: text }
-      end
-
-      nutrition = {
-        calories: input["calories"],
-        fat: input["fat"],
-        protein: input["protein"],
-        carbs: input["carbs"],
-        fiber: input["fiber"]
-      }.compact.presence
-
-      {
-        title: input["title"],
-        description: input["description"],
-        servings: input["servings"],
-        prep_time: input["prep_time"],
-        cook_time: input["cook_time"],
-        ingredients: input["ingredients"] || [],
-        instructions: instructions,
-        nutrition: nutrition
-      }.compact
     end
   end
 end


### PR DESCRIPTION
## Summary

Extracts three areas of duplicated code into shared modules/concerns: import service normalize methods, recipe params permit lists, and meal plan setup logic.

## Changes

- **`RecipeImport::Normalizer`** module — extracted identical `normalize` method from `AiExtractor` and `PhotoExtractor` (JsonLdParser untouched as it has a structurally different pipeline)
- **`RecipeParamsPermittable`** concern — shared recipe attribute permit list used by both web and API recipe controllers. Web controller extends with `:image, images: []` for file uploads.
- **`MealPlanSetupable`** concern — shared `generate_days` and `attach_participants` methods used by both web and API meal plan controllers

## Documentation

- No changes needed (internal refactor, no behavior change)

## Testing

- All 1077 tests pass (pure refactor, no behavior changes)
- Rubocop: 0 offenses
- Brakeman: 0 warnings

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)